### PR TITLE
Added exception to test cash file alarm

### DIFF
--- a/HousingFinanceInterimApi/V1/UseCase/ImportCashFileUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/ImportCashFileUseCase.cs
@@ -47,6 +47,8 @@ namespace HousingFinanceInterimApi.V1.UseCase
         {
             LoggingHandler.LogInfo($"Starting cash file import");
 
+            throw new InvalidOperationException("Hello world");
+
             var batch = await _batchLogGateway.CreateAsync(_cashFileLabel).ConfigureAwait(false);
             var googleFileSettings = await GetGoogleFileSetting(_cashFileLabel).ConfigureAwait(false);
 


### PR DESCRIPTION
Exception added in ImportCashFileUseCase to always throw, in order to see how this will appear on CloudWatch and in the Alarm Email