### PR TITLE
Throw errors and trycatch in importCashFileUseCase

### DIFF
--- a/HousingFinanceInterimApi/V1/UseCase/ImportCashFileUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/ImportCashFileUseCase.cs
@@ -45,7 +45,8 @@ namespace HousingFinanceInterimApi.V1.UseCase
         public async Task<StepResponse> ExecuteAsync()
         {
             var errorMessage = "An error occurred processing the cash file";
-            try {
+            try
+            {
                 LoggingHandler.LogInfo($"Starting cash file import");
 
                 var batch = await _batchLogGateway.CreateAsync(_cashFileLabel).ConfigureAwait(false);


### PR DESCRIPTION
[Jira Ticket](https://hackney.atlassian.net/jira/software/projects/POH/boards/100?selectedIssue=POH-11)

Put main `ExecuteAsync` contents in a try-catch block, where any caught exception is caught  and re-thrown after a `LogError`.

Changed several `LogInfo`s into `LogError`s as appropriate.

Threw exceptions where appropriate, with context-specific information in the messages.