### PR TITLE
Upgrade of the application to dotnet 6.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -50,7 +50,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/HousingFinanceInterimApi.Tests/Dockerfile
+++ b/HousingFinanceInterimApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
@@ -16,6 +16,6 @@ RUN dotnet restore ./HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tes
 # Copy everything else and build
 COPY . .
 
-RUN dotnet build -c debug -o out HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
+RUN dotnet build ./HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
 
 CMD dotnet test

--- a/HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
+++ b/HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/HousingFinanceInterimApi/Dockerfile
+++ b/HousingFinanceInterimApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 WORKDIR /app
 

--- a/HousingFinanceInterimApi/HousingFinanceInterimApi.csproj
+++ b/HousingFinanceInterimApi/HousingFinanceInterimApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/HousingFinanceInterimApi/Startup.cs
+++ b/HousingFinanceInterimApi/Startup.cs
@@ -51,7 +51,7 @@ namespace HousingFinanceInterimApi
 
 
             services.AddCors();
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
 
             services.AddApiVersioning(o =>
             {

--- a/HousingFinanceInterimApi/build.cmd
+++ b/HousingFinanceInterimApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/housing-finance-interim-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/housing-finance-interim-api.zip

--- a/HousingFinanceInterimApi/build.sh
+++ b/HousingFinanceInterimApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/housing-finance-interim-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/housing-finance-interim-api.zip

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -2,7 +2,7 @@ service: housing-finance-interim-api
 provider:
   name: aws
   timeout: 300
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
@@ -27,7 +27,7 @@ provider:
     S3_OBJECT_PREFIX: ${ssm:/housing-finance/${self:provider.stage}/s3-object-prefix}
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/housing-finance-interim-api.zip
+  artifact: ./bin/release/net6.0/housing-finance-interim-api.zip
 
 functions:
   interimFinanceSystem:


### PR DESCRIPTION
# What:
 - A framework upgrade to dotnet version 6.

# Why:
 - The version 3.1 core life cycle has ended.

# Notes:
 - This upgrade work has a lot less nuget package version upgrades. It should still work fine as the packages seem to be supporting the correct .NET Standard versions for them to continue working fine. However, given this application has close to no tests, I don't feel comfortable to upgrading the packages to versions that are targeting dotnet 6 at a minimum.
 - Version 6 was chosen instead of version 7 due to it being an LTS version.