### PR TITLE
Added support for drive file query "fields" override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ tmp/
 .fake
 .ionide
 /HousingFinanceInterimApi/Properties/launchSettings.json
+
+*.env

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty @FaisalHackney @LBHackney-IT/mtfh-finance
+* @LBHSPreston @FaisalHackney @LBHackney-IT/mtfh-finance

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -66,7 +66,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>()))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
                 .ReturnsAsync(new List<File>());
 
             _mockGoogleClientService
@@ -109,7 +109,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>()))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
                 .ReturnsAsync(new List<File>());
 
             _mockGoogleClientService

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/ImportCashFileUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/ImportCashFileUseCaseTests.cs
@@ -104,7 +104,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
         private void SetUpGoogleClientService(List<File> fileList)
         {
-            _googleClientService.Setup(service => service.GetFilesInDriveAsync(_googleIdentifier)).ReturnsAsync(fileList);
+            _googleClientService.Setup(service => service.GetFilesInDriveAsync(_googleIdentifier, null)).ReturnsAsync(fileList);
             _googleClientService.Setup(service => service.ReadFileLineDataAsync(fileList[1].Name,
                                                                                 fileList[1].Id,
                                                                                 fileList[1].MimeType))

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/MoveHousingBenefitFileUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/MoveHousingBenefitFileUseCaseTests.cs
@@ -60,11 +60,11 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(destinationFolders.ToList());
 
             // destination folder files
-            _mockGoogleClientService.Setup(g => g.GetFilesInDriveAsync(It.IsAny<string>())).ReturnsAsync(new List<File>());
+            _mockGoogleClientService.Setup(g => g.GetFilesInDriveAsync(It.IsAny<string>(), null)).ReturnsAsync(new List<File>());
 
             // source folder files
             _mockGoogleClientService
-                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolders.First().GoogleIdentifier)))
+                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolders.First().GoogleIdentifier), null))
                 .ReturnsAsync(academyFolderFiles.ToList());
         }
 
@@ -136,7 +136,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Return a couple files to avoid failure
             _mockGoogleClientService
-                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFileSettings.First().GoogleIdentifier)))
+                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFileSettings.First().GoogleIdentifier), null))
                 .ReturnsAsync(RandomGen.GoogleDriveFiles(true).ToList());
 
             // act
@@ -145,7 +145,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // assert
             academyFileSettings.ForEach((academyFileSetting) =>
                 _mockGoogleClientService.Verify(
-                    g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFileSetting.GoogleIdentifier)),
+                    g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFileSetting.GoogleIdentifier), null),
                     Times.Once
                 )
             );
@@ -168,7 +168,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // assert
             destinationFileSettings.ForEach(destinationFolder =>
                 _mockGoogleClientService.Verify(
-                    g => g.GetFilesInDriveAsync(It.Is<string>(s => s == destinationFolder.GoogleIdentifier)),
+                    g => g.GetFilesInDriveAsync(It.Is<string>(s => s == destinationFolder.GoogleIdentifier), null),
                     Times.Once
                 )
             );
@@ -212,11 +212,11 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var destinationFolderGId = destinationFolders.First().GoogleIdentifier;
 
             _mockGoogleClientService
-                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolderGId)))
+                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolderGId), null))
                     .ReturnsAsync(academyFolderFiles.ToList());
 
             _mockGoogleClientService
-                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == destinationFolderGId)))
+                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == destinationFolderGId), null))
                     .ReturnsAsync(destinationFolderFiles.ToList());
 
             // act
@@ -279,11 +279,11 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var destinationFolderGId = destinationFolders.First().GoogleIdentifier;
 
             _mockGoogleClientService
-                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolderGId)))
+                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolderGId), null))
                 .ReturnsAsync(academyFolderFiles.ToList());
 
             _mockGoogleClientService
-                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == destinationFolderGId)))
+                .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == destinationFolderGId), null))
                 .ReturnsAsync(destinationFolderFiles.ToList());
 
             // act
@@ -391,7 +391,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(academyFolders.ToList());
 
             _mockGoogleClientService
-                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolders.First().GoogleIdentifier)))
+                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolders.First().GoogleIdentifier), null))
                     .ReturnsAsync(academyFiles.ToList());
 
             _mockGoogleFileSettingGateway
@@ -440,7 +440,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(academyFolders.ToList());
 
             _mockGoogleClientService
-                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolders.First().GoogleIdentifier)))
+                    .Setup(g => g.GetFilesInDriveAsync(It.Is<string>(s => s == academyFolders.First().GoogleIdentifier), null))
                     .ReturnsAsync(academyFolderFiles);
 
             // act
@@ -511,7 +511,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var folderNotFoundException = ErrorGen.FileNotFoundException();
 
             _mockGoogleClientService
-                .Setup(g => g.GetFilesInDriveAsync(It.IsAny<string>()))
+                .Setup(g => g.GetFilesInDriveAsync(It.IsAny<string>(), null))
                 .ThrowsAsync(folderNotFoundException);
 
             _mockBatchLogGateway

--- a/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
@@ -141,7 +141,7 @@ namespace HousingFinanceInterimApi.V1.Gateways
             listRequest.Q = $"'{driveId}' in parents";
             if (!string.IsNullOrWhiteSpace(fieldsOverride))
             {
-                listRequest.Fields = fieldsOverride;
+                listRequest.Fields = fieldsOverride.Trim();
             }
 
             // Recursively get files from drive

--- a/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
@@ -135,16 +135,20 @@ namespace HousingFinanceInterimApi.V1.Gateways
         /// <returns>
         /// The list of files for the given drive.
         /// </returns>
-        public async Task<IList<Google.Apis.Drive.v3.Data.File>> GetFilesInDriveAsync(string driveId)
+        public async Task<IList<Google.Apis.Drive.v3.Data.File>> GetFilesInDriveAsync(string driveId, string fieldsOverride = null)
         {
             FilesResource.ListRequest listRequest = _driveService.Files.List();
             listRequest.Q = $"'{driveId}' in parents";
+            if (!string.IsNullOrWhiteSpace(fieldsOverride))
+            {
+                listRequest.Fields = fieldsOverride;
+            }
 
             // Recursively get files from drive
             return await GetFilesInDrive(listRequest, null).ConfigureAwait(false);
         }
 
-        public async Task<File> GetFilesInDriveAsync(string driveId, string fileName)
+        public async Task<File> GetFileByNameInDriveAsync(string driveId, string fileName)
         {
             var files = await GetFilesInDriveAsync(driveId).ConfigureAwait(false);
 

--- a/HousingFinanceInterimApi/V1/Gateways/Interface/IGoogleClientService.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/Interface/IGoogleClientService.cs
@@ -16,10 +16,16 @@ namespace HousingFinanceInterimApi.V1.Gateways.Interface
         /// Gets the files in drive asynchronous.
         /// </summary>
         /// <param name="driveId">The drive identifier.</param>
+        /// <param name="fieldsOverride">A custom list of fields to fetch from the google drive api response.</param>
         /// <returns>The list of files for the given drive.</returns>
-        public Task<IList<Google.Apis.Drive.v3.Data.File>> GetFilesInDriveAsync(string driveId);
+        public Task<IList<Google.Apis.Drive.v3.Data.File>> GetFilesInDriveAsync(string driveId, string fieldsOverride = null);
 
-        public Task<Google.Apis.Drive.v3.Data.File> GetFilesInDriveAsync(string driveId, string fileName);
+        /// <summary>
+        /// Gets the files in a drive folder asynchronously by name.
+        /// </summary>
+        /// <param name="driveId">The drive identifier.</param>
+        /// <returns>The list of files for the given drive.</returns>
+        public Task<Google.Apis.Drive.v3.Data.File> GetFileByNameInDriveAsync(string driveId, string fileName);
 
         /// <summary>
         /// Reads the file line data asynchronous.

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -114,7 +114,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             System.Threading.Thread.Sleep(_sleepDuration);
 
             var file = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
 
             var fileLink = $"https://drive.google.com/file/d/{file.Id}";
@@ -161,7 +161,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             System.Threading.Thread.Sleep(_sleepDuration);
 
             var file = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
 
             var fileLink = $"https://drive.google.com/file/d/{file.Id}";
@@ -194,7 +194,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             System.Threading.Thread.Sleep(_sleepDuration);
 
             var file = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
 
             var fileLink = $"https://drive.google.com/file/d/{file.Id}";
@@ -227,7 +227,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             System.Threading.Thread.Sleep(_sleepDuration);
 
             var file = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
 
             var fileLink = $"https://drive.google.com/file/d/{file.Id}";
@@ -260,7 +260,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             System.Threading.Thread.Sleep(_sleepDuration);
 
             var file = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
 
             var fileLink = $"https://drive.google.com/file/d/{file.Id}";


### PR DESCRIPTION
## Link to JIRA ticket

[Changes to the HB file behaviour](https://hackney.atlassian.net/jira/software/projects/POH/boards/100?selectedIssue=POH-44)

## Describe this PR
Part of work towards making the UseCase for processing the Housing Benefit file work even if the file is not dropped on the correct day and with the correct filename, and to alert us in case it does not work as expected.

By default the Google Drive API does not return the CreatedTime field of files. This field is currently needed in the updated implementation of the MoveHousingBenefitUseCase.

A default-null argument `fieldsOverride` was added to the `GetFilesInDriveAsync` method of the GoogleClientService, which can be used to optionally select specific non-default fields to fetch from the API. This allows the MoveHousingBenefitUseCase to get file CreatedTime without affecting any other UseCases that use this method.