### PR TITLE
POH-55-charges-transactions-timeout-issue

### DIFF
--- a/HousingFinanceInterimApi/V1/Infrastructure/DatabaseContext.cs
+++ b/HousingFinanceInterimApi/V1/Infrastructure/DatabaseContext.cs
@@ -365,7 +365,7 @@ namespace HousingFinanceInterimApi.V1.Infrastructure
             => await PerformTransaction("usp_LoadTransactionsCashFile", 600).ConfigureAwait(false);
 
         public async Task LoadChargesTransactions(int @processingYear)
-            => await PerformInterpolatedTransaction($"usp_LoadTransactionsCharges {@processingYear}", 600).ConfigureAwait(false);
+            => await PerformInterpolatedTransaction($"usp_LoadTransactionsCharges {@processingYear}", 900).ConfigureAwait(false);
 
         public async Task LoadHousingFileTransactions()
             => await PerformTransaction("usp_LoadTransactionsHousingFile", 600).ConfigureAwait(false);
@@ -474,7 +474,7 @@ namespace HousingFinanceInterimApi.V1.Infrastructure
             return results;
         }
 
-        //REPORTS    
+        //REPORTS
         public async Task<List<string[]>> GetCashSuspenseAccountByYearAsync(int year, string suspenseAccountType)
         {
             var results = new List<string[]>();


### PR DESCRIPTION
## [POH-55](https://hackney.atlassian.net/jira/software/projects/POH/boards/100?selectedIssue=POH-55) Charges Transactions SQL Timeout Resolution

## What
Increased timeout on Load Charges Transactions database stored procedure execution from 600s (10m) to 900s (15m).

## Why
The stored procedure execution is timing out which throws an exception and causes the lambda execution to fail, it is inferred this is due to too much data processed at once.

[POH-55]: https://hackney.atlassian.net/browse/POH-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ