### PR TITLE
Add `x-correlation-id` to allowed headers

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -54,6 +54,7 @@ functions:
               - X-Api-Key
               - X-Amz-Security-Token
               - X-Amz-User-Agent
+              - x-correlation-id
             allowCredentials: false
       - http:
           path: /swagger/{proxy+}


### PR DESCRIPTION
## Summary of Changes

MMH frontend requests include the `x-correlation-id` header by default. This change will allow any request to include the header without causing a CORS error.