### PR TITLE
Invert authorization for MMH integration 

### DIFF
--- a/HousingFinanceInterimApi/V1/Controllers/AssetController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/AssetController.cs
@@ -23,7 +23,6 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPatch]
         [Route("{propertyReference}")]
-        [AuthorizeEndpointByGroups("ASSET_ADMIN_GROUPS")]
         public async Task<IActionResult> UpdateAssetDetails([FromRoute] UpdateAssetDetailsQuery query, [FromBody] UpdateAssetDetailsRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.AddressLine1))

--- a/HousingFinanceInterimApi/V1/Controllers/BatchController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/BatchController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using HousingFinanceInterimApi.V1.Boundary.Response;
+using Hackney.Core.Authorization;
 
 namespace HousingFinanceInterimApi.V1.Controllers
 {
@@ -29,6 +30,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("errors")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> GetErrors()
         {
             var data = await _getBatchLogErrorUseCase.ExecuteAsync().ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/Controllers/OperatingBalanceController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/OperatingBalanceController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Cors;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using HousingFinanceInterimApi.V1.Infrastructure;
+using Hackney.Core.Authorization;
 
 namespace HousingFinanceInterimApi.V1.Controllers
 {
@@ -27,6 +28,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> Get(DateTime? startDate, DateTime? endDate, int startWeek, int startYear, int endWeek, int endYear)
         {
             var data = await _gateway.ListAsync(startDate, endDate, startWeek, startYear, endWeek, endYear).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/Controllers/PaymentController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/PaymentController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Cors;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using HousingFinanceInterimApi.V1.Infrastructure;
+using Hackney.Core.Authorization;
 
 namespace HousingFinanceInterimApi.V1.Controllers
 {
@@ -28,6 +29,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> Get(string tenancyAgreementRef, string rentAccount, string householdRef, int count, string order)
         {
             var data = await _gateway.ListAsync(tenancyAgreementRef, rentAccount, householdRef, count, order).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/Controllers/ReportController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/ReportController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using HousingFinanceInterimApi.V1.Infrastructure;
 using HousingFinanceInterimApi.V1.Domain;
 using HousingFinanceInterimApi.V1.Boundary.Response;
+using Hackney.Core.Authorization;
 
 namespace HousingFinanceInterimApi.V1.Controllers
 {
@@ -36,6 +37,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         [Route("charges")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> CreateReportCharges([FromBody] BatchReportChargesRequest request)
         {
             var batchReport = request.ToDomain();
@@ -54,6 +56,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("charges")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> ListReportCharges()
         {
             var batchReportCharges = await _batchReportGateway
@@ -68,6 +71,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         [Route("cash/suspense")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> CreateReportCashSuspense([FromBody] BatchReportCashSuspenseRequest request)
         {
             var batchReport = request.ToDomain();
@@ -86,6 +90,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("cash/suspense")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> ListReportCashSuspense()
         {
             var batchReportCharges = await _batchReportGateway
@@ -100,6 +105,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         [Route("cash/import")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> CreateReportCashImport([FromBody] BatchReportCashImportRequest request)
         {
             var batchReport = request.ToDomain();
@@ -118,6 +124,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("cash/import")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> ListReportCashImport()
         {
             var batchReportCharges = await _batchReportGateway
@@ -132,6 +139,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         [Route("balance")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> CreateReportAccountBalance([FromBody] BatchReportAccountBalanceRequest request)
         {
             var batchReport = request.ToDomain();
@@ -150,6 +158,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("balance")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> ListReportAccountBalance()
         {
             var batchReportAccountBalance = await _batchReportGateway
@@ -164,6 +173,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         [Route("housingbenefit/academy")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> CreateReportHousingBenefitAcademy([FromBody] BatchReportHousingBenefitAcademyRequest request)
         {
             var batchReport = request.ToDomain();
@@ -182,6 +192,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("housingbenefit/academy")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> ListReportHousingBenefitAcademy()
         {
             var batchReportHousingBenefitAcademy = await _batchReportGateway

--- a/HousingFinanceInterimApi/V1/Controllers/TenancyController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/TenancyController.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.AspNetCore.Http;
 using HousingFinanceInterimApi.V1.Infrastructure;
 using System.Collections.Generic;
+using Hackney.Core.Authorization;
 
 namespace HousingFinanceInterimApi.V1.Controllers
 {
@@ -29,6 +30,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> Get(string tenancyAgreementRef, string rentAccount, string householdRef)
         {
             var data = await _gateway.GetAsync(tenancyAgreementRef, rentAccount, householdRef).ConfigureAwait(false);
@@ -42,6 +44,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("transaction")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> GetTransactions(string tenancyAgreementRef, string rentAccount, string householdRef,
             int count, string order, DateTime startDate, DateTime endDate)
         {

--- a/HousingFinanceInterimApi/V1/Controllers/TransactionController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/TransactionController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using System.Transactions;
+using Hackney.Core.Authorization;
 
 namespace HousingFinanceInterimApi.V1.Controllers
 {
@@ -27,6 +28,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [Route("summary")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
         public async Task<IActionResult> Get(DateTime? startDate, DateTime? endDate)
         {
             var data = await _gateway.ListAsync(startDate, endDate).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/UseCase/MoveHousingBenefitFileUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/MoveHousingBenefitFileUseCase.cs
@@ -78,7 +78,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     throw new SIO.FileNotFoundException($"No files were found within the '{_academyFileFolderLabel}' label directories.");
 
                 // Filters the list to only contain the most recent valid file to copy.
-                var validRenamedAcademyFiles = FilterAcademyFileToCopy(academyFiles, destinationGoogleFileSettings);
+                var validRenamedAcademyFiles = FilterAcademyFileToCopy(academyFiles);
 
                 var destinationFolderWithFiles = await Task.WhenAll(
                     destinationGoogleFileSettings.Select(async setting =>
@@ -171,7 +171,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             }
         }
 
-        private List<FileCopyObject> FilterAcademyFileToCopy(List<File> academyFiles, List<GoogleFileSettingDomain> destinationGoogleFileSettings)
+        private List<FileCopyObject> FilterAcademyFileToCopy(List<File> academyFiles)
         {
             // From the files in the Academy folder, select ones created in last week and rename them.
             // If multiple files in valid week, select the first one only.

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -25,7 +25,7 @@ provider:
     CHARGES_BATCH_YEARS: ${ssm:/housing-finance/${self:provider.stage}/charges-batch-years}
     S3_BUCKET_NAME: ${ssm:/housing-finance/${self:provider.stage}/s3-bucket-name}
     S3_OBJECT_PREFIX: ${ssm:/housing-finance/${self:provider.stage}/s3-object-prefix}
-    ASSET_ADMIN_GROUPS: ${ssm:/housing-finance/${self:provider.stage}/asset-api-admin-allowed-groups}
+    HOUSING_FINANCE_ALLOWED_GROUPS: ${ssm:/housing-finance/${self:provider.stage}/housing-finance-allowed-groups}
 
 package:
   artifact: ./bin/release/net6.0/housing-finance-interim-api.zip


### PR DESCRIPTION
## Summary of Changes

There is a new integration between MMH property and HousingFinance. The user groups `mmh-asset-admin` and `mmh-project-team` have been granted access to this API. However, this means users in these groups have access to all API endpoints.

To mitigate this, I have added authorization to all of other API endpoints, which will be populated with the current google groups for housing finance.