### PR TITLE
new functionality to delete files later than 7 days in rent position

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/Gateways/UPCashFileNameTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/UPCashFileNameTests.cs
@@ -47,11 +47,10 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             Assert.Equal(fileName, getResult.FileName);
         }
 
-        public async Task GetNotExists()
+        public Task GetNotExists()
         {
-
+            return Task.CompletedTask;
         }
-
     }
 
 }

--- a/HousingFinanceInterimApi.Tests/V1/Gateways/UPCashFileNameTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/UPCashFileNameTests.cs
@@ -46,11 +46,6 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             Assert.NotNull(getResult);
             Assert.Equal(fileName, getResult.FileName);
         }
-
-        public Task GetNotExists()
-        {
-            return Task.CompletedTask;
-        }
     }
 
 }

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -188,7 +188,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
 
             // Act
-           var usecaseCall = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
             // Assert
             _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(fileToBeDeleted.Id), Times.Once);

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -208,7 +208,6 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             fileToBeDeleted.CreatedTime = DateTime.Today.AddDays(-10);
             fileToNotBeDeleted.CreatedTime = DateTime.Today.AddDays(-2);
 
-            //TODO: A way to not copy paste these mocks?
             _mockBatchLogGateway
                 .Setup(g => g.CreateAsync(It.Is<string>(s => s == rentPosition), It.IsAny<bool>()))
                 .ReturnsAsync(RandomGen.BatchLogDomain());
@@ -342,6 +341,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .Setup(g => g.GetRentPosition())
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
+            // Returns the test files
             _mockGoogleClientService
                 .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
                 .ReturnsAsync(fileList);
@@ -372,7 +372,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         [Fact]
         public async Task ThrowsExceptionIfAnyFilesFailToDelete()
         {
-             // Arrange
+            // Arrange
             var rentPositionFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
             var rentPositionBkpFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
             var rentPosition = ConstantsGen.RentPositionLabel;

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Collections.Generic;
+using Bogus.DataSets;
 using Google.Apis.Drive.v3.Data;
 
 namespace HousingFinanceInterimApi.Tests.V1.UseCase
@@ -144,7 +145,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var fileList = RandomGen.CreateMany<File>(quantity: 2).ToList();
             var fileToBeDeleted = fileList.First();
             var fileToNotBeDeleted = fileList.Last();
-            fileToBeDeleted.CreatedTime = DateTime.Today.AddDays(-10);
+            fileToBeDeleted.CreatedTime = new DateTime(2020, 1, 1);
             fileToNotBeDeleted.CreatedTime = DateTime.Today.AddDays(-2);
 
             _mockBatchLogGateway
@@ -205,7 +206,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var fileList = RandomGen.CreateMany<File>(quantity: 2).ToList();
             var fileToBeDeleted = fileList.First();
             var fileToNotBeDeleted = fileList.Last();
-            fileToBeDeleted.CreatedTime = DateTime.Today.AddDays(-10);
+            fileToBeDeleted.CreatedTime = new DateTime(2020, 6, 4);
             fileToNotBeDeleted.CreatedTime = DateTime.Today.AddDays(-2);
 
             _mockBatchLogGateway
@@ -313,6 +314,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         [Fact]
         public async Task DoesNotDeleteFilesCreatedAtTheEndOfPreviousFinancialYears()
         {
+            // Does not delete files created on 31st March
             // Arrange
             var rentPositionFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
             var rentPositionBkpFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
@@ -322,8 +324,8 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var fileToBePreserved = fileList.First();
             var fileToBeDeleted = fileList.Last();
 
-            fileToBePreserved.CreatedTime = new DateTime(2020, 3, 31);
-            fileToBeDeleted.CreatedTime = DateTime.Today.AddDays(-10);
+            fileToBePreserved.CreatedTime = new DateTime(2020, 3, 31); // Tuesday
+            fileToBeDeleted.CreatedTime = new DateTime(2020, 4, 1);
 
             _mockBatchLogGateway
                 .Setup(g => g.CreateAsync(It.Is<string>(s => s == rentPosition), It.IsAny<bool>()))
@@ -381,8 +383,8 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var fileToBePreserved = fileList.First();
             var fileToBeDeleted = fileList.Last();
 
-            fileToBePreserved.CreatedTime = new DateTime(2019, 3, 29);
-            fileToBeDeleted.CreatedTime = new DateTime(2019, 3, 31);
+            fileToBePreserved.CreatedTime = new DateTime(2019, 3, 29); // Friday
+            fileToBeDeleted.CreatedTime = new DateTime(2019, 3, 31); // Sunday
 
             _mockBatchLogGateway
                 .Setup(g => g.CreateAsync(It.Is<string>(s => s == rentPosition), It.IsAny<bool>()))
@@ -437,9 +439,12 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var rentPosition = ConstantsGen.RentPositionLabel;
             var rentPositionBkp = ConstantsGen.RentPositionBkpLabel;
             var fileList = RandomGen.CreateMany<File>(quantity: 3).ToList();
-            fileList.First().CreatedTime = DateTime.Today.AddDays(-2);
-            fileList[1].CreatedTime = DateTime.Today.AddDays(-9); // File to be deleted
-            fileList.Last().CreatedTime = DateTime.Today.AddDays(-10); // File to be deleted
+            var fileToBePreserved = fileList.First();
+            var fileToBeDeleted1 = fileList[1];
+            var fileToBeDeleted2 = fileList.Last();
+            fileToBePreserved.CreatedTime = DateTime.Today.AddDays(-2);
+            fileToBeDeleted1.CreatedTime = new DateTime(2023, 1, 11);
+            fileToBeDeleted2.CreatedTime = new DateTime(2022, 6, 13);
 
             _mockBatchLogGateway
                 .Setup(g => g.CreateAsync(It.Is<string>(s => s == rentPosition), It.IsAny<bool>()))
@@ -483,7 +488,8 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Assert
             await useCaseCall.Should().ThrowAsync<AggregateException>().ConfigureAwait(false);
-            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.IsAny<string>()), Times.Exactly(2));
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.IsIn(fileToBeDeleted1.Id, fileToBeDeleted2.Id)), Times.Exactly(2));
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBePreserved.Id)), Times.Never);
             _mockGoogleClientService.Verify(x => x.UploadCsvFile(It.IsAny<List<string[]>>(), It.IsAny<string>(), rentPositionFileSettings.First().GoogleIdentifier), Times.Once);
         }
     }

--- a/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
@@ -132,6 +132,7 @@ namespace HousingFinanceInterimApi.V1.Gateways
         /// Gets the files in drive asynchronous.
         /// </summary>
         /// <param name="driveId">The drive identifier.</param>
+        /// <param name="fieldsOverride"></param>
         /// <returns>
         /// The list of files for the given drive.
         /// </returns>

--- a/HousingFinanceInterimApi/V1/Gateways/Interface/IGoogleClientService.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/Interface/IGoogleClientService.cs
@@ -24,6 +24,7 @@ namespace HousingFinanceInterimApi.V1.Gateways.Interface
         /// Gets the files in a drive folder asynchronously by name.
         /// </summary>
         /// <param name="driveId">The drive identifier.</param>
+        /// <param name="fileName"></param>
         /// <returns>The list of files for the given drive.</returns>
         public Task<Google.Apis.Drive.v3.Data.File> GetFileByNameInDriveAsync(string driveId, string fileName);
 

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -151,16 +151,25 @@ namespace HousingFinanceInterimApi.V1.UseCase
 
         /// <summary>
         /// Filters out each file that is the last file for a financial year (31st March)
-        /// </summary>
+        /// </summary
         static IEnumerable<File> getLastFilesForFinancialYears(IEnumerable<File> fileList)
         {
-            var filesOnLastDayOfFinancialYear = fileList.Where(
-                f => f.CreatedTime != null
-                     && f.CreatedTime.Value.Day == 31
-                     && f.CreatedTime.Value.Month == 3
-            );
+            // Get list of file groups on the last working in March for each year
+            var marchFileGroupsNotOnWeekend = fileList
+                .Where(f => f.CreatedTime.HasValue)
+                .OrderBy(f => f.CreatedTime)
+                .Where(f => !new[] { DayOfWeek.Saturday, DayOfWeek.Sunday }.Contains(f.CreatedTime.Value.DayOfWeek))
+                .Where(f => f.CreatedTime.Value.Month == 3)
+                .GroupBy(f => f.CreatedTime.Value.Year)
+                .ToList();
 
-            return filesOnLastDayOfFinancialYear;
+            var filesOnLastDayOfFinanacialYear = new List<File>();
+            foreach (var marchList in marchFileGroupsNotOnWeekend)
+            {
+                filesOnLastDayOfFinanacialYear.Add(marchList.Last());
+            }
+
+            return filesOnLastDayOfFinanacialYear;
         }
     }
 }

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -101,11 +101,15 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     var lastFilesForFinancialYears = getLastFilesForFinancialYears(folderFiles);
                     folderFiles = folderFiles.Where(f => !lastFilesForFinancialYears.Contains(f)).ToList();
 
+                    var filesToDelete = folderFiles.Where(f =>
+                            f.CreatedTime <= DateTime.Today.AddDays(-7)
+                            && !lastFilesForFinancialYears.Contains(f)
+                        ).ToList();
+
+                    LoggingHandler.LogInfo($"Will delete {filesToDelete.Count} files from {googleFileSetting.GoogleIdentifier}. Names: {string.Join(", ", filesToDelete.Select(f => f.Name))}");
+
                     var deletionErrors = new List<Exception>();
-                    foreach (var file in folderFiles.Where(f =>
-                                 f.CreatedTime <= DateTime.Today.AddDays(-7)
-                                    && !lastFilesForFinancialYears.Contains(f)).ToList()
-                             )
+                    foreach (var file in filesToDelete)
                     {
                         try
                         {

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -70,17 +70,18 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     LoggingHandler.LogInfo($"Folder ID: {googleFileSetting.GoogleIdentifier}");
                     LoggingHandler.LogInfo($"File count: {folderFiles.Count}");
 
+                    LoggingHandler.LogInfo($"Deleting old files");
+                    foreach (var file in folderFiles.Where(f => f.Name.Equals(fileName)).ToList())
+                    {
+                        await _googleClientService.DeleteFileInDrive(file.Id).ConfigureAwait(false);
+                    }
+
                     var isSuccess = await _googleClientService.UploadCsvFile(rentPosition, fileName, googleFileSetting.GoogleIdentifier)
                         .ConfigureAwait(false);
 
                     if (!isSuccess)
                         throw new Exception("Failed to upload to Rent Position folder (Qlik)");
 
-                    LoggingHandler.LogInfo($"Deleting old files");
-                    foreach (var file in folderFiles.Where(f => f.Name.Equals(fileName)).ToList())
-                    {
-                        await _googleClientService.DeleteFileInDrive(file.Id).ConfigureAwait(false);
-                    }
                 }
 
                 googleFileSettings = await GetGoogleFileSetting(_rentPositionBkpLabel).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -93,13 +93,14 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     var folderFiles = await _googleClientService.GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
                         .ConfigureAwait(false);
 
+                    if (!isSuccess)
+                        throw new Exception("Failed to upload to Rent Position folder (Backup)");
 
                     LoggingHandler.LogInfo("Deleting old files");
-                    foreach (var file in folderFiles.Where(f => f.CreatedTime <= DateTime.Today.AddDays(-7)).ToList())
+                    foreach (var file in folderFiles.Where(f => f.CreatedTime <= DateTime.Today.AddDays(-7)))
                     {
                         try
                         {
-
                             LoggingHandler.LogInfo($"Deleting file {file.Name}, createdTime: {file.CreatedTime}");
                             await _googleClientService.DeleteFileInDrive(file.Id).ConfigureAwait(false);
                         }
@@ -109,8 +110,6 @@ namespace HousingFinanceInterimApi.V1.UseCase
                         }
                     }
 
-                    if (!isSuccess)
-                        throw new Exception("Failed to upload to Rent Position folder (Backup)");
                 }
 
                 await _batchLogGateway.SetToSuccessAsync(batch.Id).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -106,7 +106,6 @@ namespace HousingFinanceInterimApi.V1.UseCase
                         catch
                         {
                             LoggingHandler.LogInfo($"Could not delete file {file.Name}");
-                            throw;
                         }
                     }
 


### PR DESCRIPTION
## [POH-126](https://hackney.atlassian.net/jira/software/projects/POH/boards/100?selectedIssue=POH-126)

## What
The `GenerateRentPositionUseCase` uploads new files to the Rent Position Backup Google Drive folder in Housing-Production, as well as to the Rent Position (Qlik) folder
This change makes the use case clear files older than one week in the Rent Position Backup folder
It also preserves files created on the last working of financial years (last working day up to 31 March)

## Why
The service account client has regularly been hitting its limit on space, which causes overnight processes to fail when it tries to upload new files.
For this reason we want to introduce automatic clean-up to prevent this limit being reached.
The Rent Position folder was identified as containing by far the largest proportion of file storage.

## How
On execution of this use case (daily): Loop over all files in the Rent Position folder that were created over 7 days ago and delete them
Add relevant tests to verify that only files older than 7 days and not on the last working day of financial years are cleared


[POH-126]: https://hackney.atlassian.net/browse/POH-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ