### PR TITLE
Fetch file created dates in rent position

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -67,7 +67,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<File>());
 
             _mockGoogleClientService
@@ -110,7 +110,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<File>());
 
             _mockGoogleClientService
@@ -165,7 +165,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -226,7 +226,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             // Upload to Rent Position folder fails
@@ -284,7 +284,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -348,7 +348,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Returns the test files
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -408,7 +408,65 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Returns the test files
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(fileList);
+
+            _mockGoogleClientService
+                .Setup(x => x.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.Is<string>(s => s == rentPositionFileSettings.First().GoogleIdentifier)))
+                .ReturnsAsync(true);
+
+            _mockGoogleClientService
+                .Setup(x => x.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.Is<string>(s => s == rentPositionBkpFileSettings.First().GoogleIdentifier)))
+                .ReturnsAsync(true);
+
+            // Act
+            Func<Task> useCaseCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // Assert
+            await useCaseCall.Should().NotThrowAsync<Exception>().ConfigureAwait(false);
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBeDeleted.Id)), Times.Once);
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBePreserved.Id)), Times.Never);
+        }
+
+        [Fact]
+        public async Task DoesNotDeleteFilesWithNoCreationDateSetOrFound()
+        {
+            // Arrange
+            var rentPositionFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            var rentPositionBkpFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            var rentPosition = ConstantsGen.RentPositionLabel;
+            var rentPositionBkp = ConstantsGen.RentPositionBkpLabel;
+            var fileList = RandomGen.CreateMany<File>(quantity: 2).ToList();
+            var fileToBePreserved = fileList.First();
+            var fileToBeDeleted = fileList.Last();
+            fileToBePreserved.CreatedTime = null; // Friday
+            fileToBeDeleted.CreatedTime = new DateTime(2019, 3, 31); // Sunday
+
+            _mockBatchLogGateway
+                .Setup(g => g.CreateAsync(It.Is<string>(s => s == rentPosition), It.IsAny<bool>()))
+                .ReturnsAsync(RandomGen.BatchLogDomain());
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.Is<string>(s => s == rentPosition)))
+                .ReturnsAsync(rentPositionFileSettings);
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.Is<string>(s => s == rentPositionBkp)))
+                .ReturnsAsync(rentPositionBkpFileSettings);
+
+            _mockRentPositionGateway
+                .Setup(g => g.GetRentPosition())
+                .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
+
+            // Returns the test files
+            _mockGoogleClientService
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -467,7 +525,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -97,13 +97,13 @@ namespace HousingFinanceInterimApi.V1.UseCase
                         throw new Exception("Failed to upload to Rent Position folder (Backup)");
 
                     var filesCreatedInLast7Days = folderFiles.Where(file =>
-                        file.CreatedTime.HasValue &&
-                        file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).ToList();
+                        file.CreatedTime.HasValue
+                        && file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).ToList();
                     var lastFilesForFinancialYears = getLastFilesForFinancialYears(folderFiles);
 
                     var filesToDelete = folderFiles.Where(file =>
-                            file.CreatedTime.HasValue &&
-                            !filesCreatedInLast7Days.Contains(file)
+                            file.CreatedTime.HasValue
+                            && !filesCreatedInLast7Days.Contains(file)
                             && !lastFilesForFinancialYears.Contains(file)
                         ).ToList();
 


### PR DESCRIPTION
File creation dates are null in the useCase which prevents correct filtering of files in the Drive for deletion based on these dates.

These were null because createdTime was not explicitly added to the file query of the google drive client, and so not returned.

This change adds createdTime to the query and does additional filtering to ensure no files get deleted due to missing createdTime.