### PR TITLE
Logging and proper file querying for deleting old Rent Position Backup files

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -67,7 +67,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<File>());
 
             _mockGoogleClientService
@@ -110,7 +110,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<File>());
 
             _mockGoogleClientService
@@ -165,7 +165,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -226,7 +226,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             // Upload to Rent Position folder fails
@@ -284,7 +284,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -348,7 +348,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Returns the test files
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -408,7 +408,65 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Returns the test files
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(fileList);
+
+            _mockGoogleClientService
+                .Setup(x => x.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.Is<string>(s => s == rentPositionFileSettings.First().GoogleIdentifier)))
+                .ReturnsAsync(true);
+
+            _mockGoogleClientService
+                .Setup(x => x.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.Is<string>(s => s == rentPositionBkpFileSettings.First().GoogleIdentifier)))
+                .ReturnsAsync(true);
+
+            // Act
+            Func<Task> useCaseCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // Assert
+            await useCaseCall.Should().NotThrowAsync<Exception>().ConfigureAwait(false);
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBeDeleted.Id)), Times.Once);
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBePreserved.Id)), Times.Never);
+        }
+
+        [Fact]
+        public async Task DoesNotDeleteFilesWithNoCreationDateSetOrFound()
+        {
+            // Arrange
+            var rentPositionFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            var rentPositionBkpFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
+            var rentPosition = ConstantsGen.RentPositionLabel;
+            var rentPositionBkp = ConstantsGen.RentPositionBkpLabel;
+            var fileList = RandomGen.CreateMany<File>(quantity: 2).ToList();
+            var fileToBePreserved = fileList.First();
+            var fileToBeDeleted = fileList.Last();
+            fileToBePreserved.CreatedTime = null; // Friday
+            fileToBeDeleted.CreatedTime = new DateTime(2019, 3, 31); // Sunday
+
+            _mockBatchLogGateway
+                .Setup(g => g.CreateAsync(It.Is<string>(s => s == rentPosition), It.IsAny<bool>()))
+                .ReturnsAsync(RandomGen.BatchLogDomain());
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.Is<string>(s => s == rentPosition)))
+                .ReturnsAsync(rentPositionFileSettings);
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.Is<string>(s => s == rentPositionBkp)))
+                .ReturnsAsync(rentPositionBkpFileSettings);
+
+            _mockRentPositionGateway
+                .Setup(g => g.GetRentPosition())
+                .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
+
+            // Returns the test files
+            _mockGoogleClientService
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService
@@ -467,7 +525,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(RandomGen.RentPositionCsvRepresentation());
 
             _mockGoogleClientService
-                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), null))
+                .Setup(x => x.GetFilesInDriveAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(fileList);
 
             _mockGoogleClientService

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateRentPositionUseCaseTests.cs
@@ -320,11 +320,14 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var rentPositionBkpFileSettings = RandomGen.CreateMany<GoogleFileSettingDomain>(quantity: 1).ToList();
             var rentPosition = ConstantsGen.RentPositionLabel;
             var rentPositionBkp = ConstantsGen.RentPositionBkpLabel;
-            var fileList = RandomGen.CreateMany<File>(quantity: 2).ToList();
-            var fileToBePreserved = fileList.First();
+            var fileList = RandomGen.CreateMany<File>(quantity: 3).ToList();
+            var fileToBePreserved1 = fileList.First();
+            var fileToBePreserved2 = fileList[1];
             var fileToBeDeleted = fileList.Last();
 
-            fileToBePreserved.CreatedTime = new DateTime(2020, 3, 31); // Tuesday
+
+            fileToBePreserved1.CreatedTime = new DateTime(2020, 3, 31); // Tuesday last wd of financial year
+            fileToBePreserved2.CreatedTime = DateTime.Today.AddDays(-3); // Less than 1 week old
             fileToBeDeleted.CreatedTime = new DateTime(2020, 4, 1);
 
             _mockBatchLogGateway
@@ -367,8 +370,9 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             // Assert
             await useCaseCall.Should().NotThrowAsync<Exception>().ConfigureAwait(false);
-            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBeDeleted.Id)), Times.Once);
-            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBePreserved.Id)), Times.Never);
+            _mockGoogleClientService.Verify(s => s.DeleteFileInDrive(It.Is<string>(s => s == fileToBeDeleted.Id)), Times.Once);
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBePreserved1.Id)), Times.Never);
+            _mockGoogleClientService.Verify(x => x.DeleteFileInDrive(It.Is<string>(s => s == fileToBePreserved2.Id)), Times.Never);
         }
 
         [Fact]

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -108,7 +108,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     string fileSummary(File file) => $"{file.Name} Created:({file.CreatedTime?.Date:dd/MM/yyyy})";
                     LoggingHandler.LogInfo($"All files: [{string.Join(", ", folderFiles.Select(fileSummary))}]");
                     LoggingHandler.LogInfo($"Preserving last files for past financial years: [{string.Join(", ", lastFilesForFinancialYears.Select(fileSummary))}]");
-                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", folderFiles.Where(file => file.CreatedTime?.Date >= DateTime.Today.AddDays(-7).Date).Select(fileSummary))}]");
+                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", folderFiles.Where(file => file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).Select(fileSummary))}]");
 
                     LoggingHandler.LogInfo($"Will delete {filesToDelete.Count} file(s) from {googleFileSetting.GoogleIdentifier}: [{string.Join(", ", filesToDelete.Select(f => f.Name))}]");
 

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -101,14 +101,14 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     var lastFilesForFinancialYears = getLastFilesForFinancialYears(folderFiles);
 
                     var filesToDelete = folderFiles.Where(file =>
-                            file.CreatedTime <= DateTime.Today.AddDays(-7)
+                            file.CreatedTime?.Date <= DateTime.Today.AddDays(-7).Date
                             && !lastFilesForFinancialYears.Contains(file)
                         ).ToList();
 
                     string fileSummary(File file) => $"{file.Name} Created:({file.CreatedTime?.Date:dd/MM/yyyy})";
                     LoggingHandler.LogInfo($"All files: [{string.Join(", ", folderFiles.Select(fileSummary))}]");
                     LoggingHandler.LogInfo($"Preserving last files for past financial years: [{string.Join(", ", lastFilesForFinancialYears.Select(fileSummary))}]");
-                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", folderFiles.Where(file => file.CreatedTime >= DateTime.Today.AddDays(-7)).Select(fileSummary))}]");
+                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", folderFiles.Where(file => file.CreatedTime?.Date >= DateTime.Today.AddDays(-7).Date).Select(fileSummary))}]");
 
                     LoggingHandler.LogInfo($"Will delete {filesToDelete.Count} file(s) from {googleFileSetting.GoogleIdentifier}: [{string.Join(", ", filesToDelete.Select(f => f.Name))}]");
 

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -97,13 +97,13 @@ namespace HousingFinanceInterimApi.V1.UseCase
                         throw new Exception("Failed to upload to Rent Position folder (Backup)");
 
                     var filesCreatedInLast7Days = folderFiles.Where(file =>
-                        file.CreatedTime.HasValue &&
-                        file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).ToList();
+                        file.CreatedTime.HasValue
+                        && file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).ToList();
                     var lastFilesForFinancialYears = getLastFilesForFinancialYears(folderFiles);
 
                     var filesToDelete = folderFiles.Where(file =>
-                            file.CreatedTime.HasValue &&
-                            !filesCreatedInLast7Days.Contains(file)
+                            file.CreatedTime.HasValue
+                            && !filesCreatedInLast7Days.Contains(file)
                             && !lastFilesForFinancialYears.Contains(file)
                         ).ToList();
 

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -95,18 +95,22 @@ namespace HousingFinanceInterimApi.V1.UseCase
                     if (!isSuccess)
                         throw new Exception("Failed to upload to Rent Position folder (Backup)");
 
-                    LoggingHandler.LogInfo("Deleting old files");
+                    LoggingHandler.LogInfo("Deleting old backup files");
 
                     // Keep a record of the last file for each financial year
                     var lastFilesForFinancialYears = getLastFilesForFinancialYears(folderFiles);
-                    folderFiles = folderFiles.Where(f => !lastFilesForFinancialYears.Contains(f)).ToList();
 
-                    var filesToDelete = folderFiles.Where(f =>
-                            f.CreatedTime <= DateTime.Today.AddDays(-7)
-                            && !lastFilesForFinancialYears.Contains(f)
+                    var filesToDelete = folderFiles.Where(file =>
+                            file.CreatedTime <= DateTime.Today.AddDays(-7)
+                            && !lastFilesForFinancialYears.Contains(file)
                         ).ToList();
 
-                    LoggingHandler.LogInfo($"Will delete {filesToDelete.Count} files from {googleFileSetting.GoogleIdentifier}. Names: {string.Join(", ", filesToDelete.Select(f => f.Name))}");
+                    string fileSummary(File file) => $"{file.Name} Created:({file.CreatedTime?.Date:dd/MM/yyyy})";
+                    LoggingHandler.LogInfo($"All files: [{string.Join(", ", folderFiles.Select(fileSummary))}]");
+                    LoggingHandler.LogInfo($"Preserving last files for past financial years: [{string.Join(", ", lastFilesForFinancialYears.Select(fileSummary))}]");
+                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", folderFiles.Where(file => file.CreatedTime >= DateTime.Today.AddDays(-7)).Select(fileSummary))}]");
+
+                    LoggingHandler.LogInfo($"Will delete {filesToDelete.Count} file(s) from {googleFileSetting.GoogleIdentifier}: [{string.Join(", ", filesToDelete.Select(f => f.Name))}]");
 
                     var deletionErrors = new List<Exception>();
                     foreach (var file in filesToDelete)

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -99,17 +99,17 @@ namespace HousingFinanceInterimApi.V1.UseCase
 
                     // Keep a record of the last file for each financial year
                     var lastFilesForFinancialYears = getLastFilesForFinancialYears(folderFiles);
+                    var filesCreatedInLast7Days = folderFiles.Where(file =>
+                        file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).ToList();
 
                     var filesToDelete = folderFiles.Where(file =>
-                            file.CreatedTime?.Date <= DateTime.Today.AddDays(-7).Date
-                            && !lastFilesForFinancialYears.Contains(file)
+                            !filesCreatedInLast7Days.Contains(file) && !lastFilesForFinancialYears.Contains(file)
                         ).ToList();
 
                     string fileSummary(File file) => $"{file.Name} Created:({file.CreatedTime?.Date:dd/MM/yyyy})";
                     LoggingHandler.LogInfo($"All files: [{string.Join(", ", folderFiles.Select(fileSummary))}]");
                     LoggingHandler.LogInfo($"Preserving last files for past financial years: [{string.Join(", ", lastFilesForFinancialYears.Select(fileSummary))}]");
-                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", folderFiles.Where(file => file.CreatedTime?.Date > DateTime.Today.AddDays(-7).Date).Select(fileSummary))}]");
-
+                    LoggingHandler.LogInfo($"Preserving files created in the last 7 days: [{string.Join(", ", filesCreatedInLast7Days.Select(fileSummary))}]");
                     LoggingHandler.LogInfo($"Will delete {filesToDelete.Count} file(s) from {googleFileSetting.GoogleIdentifier}: [{string.Join(", ", filesToDelete.Select(f => f.Name))}]");
 
                     var deletionErrors = new List<Exception>();


### PR DESCRIPTION
Extends and fixed bugs in https://github.com/LBHackney-IT/housing-finance-interim-api/pull/103
Added logging in https://github.com/LBHackney-IT/housing-finance-interim-api/pull/105
Fixed the google client file query in https://github.com/LBHackney-IT/housing-finance-interim-api/pull/106

Summary:
Delete old RentPosition backup files to free up storage space going forwards.

The google client needs to query file createdDate explicitly, so the UseCase can use that to filter by it and fulfill these requirements:

Keep RentPosition Backup files created in the last 7 calendar days
Keep RentPosition Backup files created on the last working days of financial years
Delete other RentPosition Backup files
Key commit: https://github.com/LBHackney-IT/housing-finance-interim-api/commit/cd8b99174a2e6459f25fc51d71024de6530d9f3d

Lambda logs for the test:
```
  [INFO]: All files: [20230223_050110.csv Created:(23/02/2023), 20230822_100021.csv Created:(22/08/2023)]
  [INFO]: Preserving last files for past financial years: []
  [INFO]: Preserving files created in the last 7 days: [20230822_100021.csv Created:(22/08/2023)]
  [INFO]: Will delete 1 backup file(s) from 1H2OFgqKSApyLMAz9gGNnTJDRq0_D0XWn: [20230223_050110.csv]
  [INFO]: Deleting file 20230223_050110.csv, createdTime: 2/23/2023 2:58:09 PM
```
