### PR TITLE
Remove old Charges process and Push back CashFile, DirectDebit, and AdjustmentTransactions by 1 hour

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -185,7 +185,7 @@ functions:
         - schedule: cron(0 5 * * ? *)
   importAdjustmentsTransactions:
     name: ${self:service}-${self:provider.stage}-adjustments-trans
-    description: "The scheduler to import adjustments transactions from spreadsheet."
+    description: "The scheduler to import adjustments transactions from spreadsheet. Runs at 2:45 AM."
     timeout: 600
     handler: HousingFinanceInterimApi::HousingFinanceInterimApi.Handler::LoadAdjustmentsTransactions
     role: lambdaExecutionRole
@@ -220,7 +220,7 @@ stepFunctions:
       events:
         - schedule: cron(0 2 * * ? *)
       definition:
-        Comment: "Cash files process step function deployed via serverless. Run at 01:00 AM"
+        Comment: "Cash files process step function deployed via serverless. Run at 02:00 AM"
         StartAt: ImportCashFile
         States:          
           ImportCashFile:
@@ -313,7 +313,7 @@ stepFunctions:
       events:
         - schedule: cron(30 2 * * ? *)
       definition:
-        Comment: "Direct debit process step function deployed via serverless. Run at 01:30 AM"
+        Comment: "Direct debit process step function deployed via serverless. Run at 02:30 AM"
         StartAt: ImportDirectDebit
         States:          
           ImportDirectDebit:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -356,84 +356,84 @@ stepFunctions:
       dependsOn: lambdaExecutionRole
       tags:
         Team: HousingFinance
-    hfstepfunccharges:
-      name: HFChargesStateMachine
-      events:
-        - schedule: cron(30 0 * * ? *)
-      definition:
-        Comment: "Charges process step function deployed via serverless. Run at 12:30 AM"
-        StartAt: CheckChargesBatchYears
-        States:
-          CheckChargesBatchYears:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ checkChargesBatchYears, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.All
-                IntervalSeconds: 30
-                MaxAttempts: 3
-                BackoffRate: 2
-            Next: Choice_ExistPendingYear
-          Choice_ExistPendingYear:
-            Type: Choice
-            Choices:
-              - Variable: $.Continue
-                BooleanEquals: true
-                Next: Wait_0
-              - Variable: $.Continue
-                BooleanEquals: false
-                Next: EndStep
-          Wait_0:
-              Type: Wait
-              TimestampPath: $.NextStepTime
-              Next: ImportCharges
-          ImportCharges:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ importCharges, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.All
-                IntervalSeconds: 30
-                MaxAttempts: 3
-                BackoffRate: 2
-            Next: Wait_1          
-          Wait_1:
-              Type: Wait
-              TimestampPath: $.NextStepTime
-              Next: ImportChargesHistory
-          ImportChargesHistory:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ importChargesHistory, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.All
-                IntervalSeconds: 30
-                MaxAttempts: 3
-                BackoffRate: 2
-            Next: Wait_2
-          Wait_2:
-              Type: Wait
-              TimestampPath: $.NextStepTime
-              Next: ImportChargesTransactions          
-          ImportChargesTransactions:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [ importChargesTransactions, Arn ]
-            Retry:
-              - ErrorEquals:
-                  - States.All
-                IntervalSeconds: 30
-                MaxAttempts: 3
-                BackoffRate: 2
-            Next: CheckChargesBatchYears
-          EndStep:
-            Type: Succeed
-      dependsOn: lambdaExecutionRole
-      tags:
-        Team: HousingFinance
+    # hfstepfunccharges:
+    #   name: HFChargesStateMachine
+    #   events:
+    #     - schedule: cron(30 0 * * ? *)
+    #   definition:
+    #     Comment: "Charges process step function deployed via serverless. Run at 12:30 AM"
+    #     StartAt: CheckChargesBatchYears
+    #     States:
+    #       CheckChargesBatchYears:
+    #         Type: Task
+    #         Resource:
+    #           Fn::GetAtt: [ checkChargesBatchYears, Arn ]
+    #         Retry:
+    #           - ErrorEquals:
+    #               - States.All
+    #             IntervalSeconds: 30
+    #             MaxAttempts: 3
+    #             BackoffRate: 2
+    #         Next: Choice_ExistPendingYear
+    #       Choice_ExistPendingYear:
+    #         Type: Choice
+    #         Choices:
+    #           - Variable: $.Continue
+    #             BooleanEquals: true
+    #             Next: Wait_0
+    #           - Variable: $.Continue
+    #             BooleanEquals: false
+    #             Next: EndStep
+    #       Wait_0:
+    #           Type: Wait
+    #           TimestampPath: $.NextStepTime
+    #           Next: ImportCharges
+    #       ImportCharges:
+    #         Type: Task
+    #         Resource:
+    #           Fn::GetAtt: [ importCharges, Arn ]
+    #         Retry:
+    #           - ErrorEquals:
+    #               - States.All
+    #             IntervalSeconds: 30
+    #             MaxAttempts: 3
+    #             BackoffRate: 2
+    #         Next: Wait_1          
+    #       Wait_1:
+    #           Type: Wait
+    #           TimestampPath: $.NextStepTime
+    #           Next: ImportChargesHistory
+    #       ImportChargesHistory:
+    #         Type: Task
+    #         Resource:
+    #           Fn::GetAtt: [ importChargesHistory, Arn ]
+    #         Retry:
+    #           - ErrorEquals:
+    #               - States.All
+    #             IntervalSeconds: 30
+    #             MaxAttempts: 3
+    #             BackoffRate: 2
+    #         Next: Wait_2
+    #       Wait_2:
+    #           Type: Wait
+    #           TimestampPath: $.NextStepTime
+    #           Next: ImportChargesTransactions          
+    #       ImportChargesTransactions:
+    #         Type: Task
+    #         Resource:
+    #           Fn::GetAtt: [ importChargesTransactions, Arn ]
+    #         Retry:
+    #           - ErrorEquals:
+    #               - States.All
+    #             IntervalSeconds: 30
+    #             MaxAttempts: 3
+    #             BackoffRate: 2
+    #         Next: CheckChargesBatchYears
+    #       EndStep:
+    #         Type: Succeed
+    #   dependsOn: lambdaExecutionRole
+    #   tags:
+    #     Team: HousingFinance
     hfstepfunccurentbalance:
       name: HFCurrentBalanceStateMachine
       events:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -190,7 +190,7 @@ functions:
     handler: HousingFinanceInterimApi::HousingFinanceInterimApi.Handler::LoadAdjustmentsTransactions
     role: lambdaExecutionRole
     events:
-        - schedule: cron(45 1 * * ? *)
+        - schedule: cron(45 2 * * ? *)
   suspenseCash:
     name: ${self:service}-${self:provider.stage}-susp-cash
     description: "The scheduler to load and reverse suspense cash files. Run at 03:05 AM"
@@ -218,7 +218,7 @@ stepFunctions:
     hfstepfunccashfile:
       name: HFCashFileStateMachine
       events:
-        - schedule: cron(0 1 * * ? *)
+        - schedule: cron(0 2 * * ? *)
       definition:
         Comment: "Cash files process step function deployed via serverless. Run at 01:00 AM"
         StartAt: ImportCashFile
@@ -311,7 +311,7 @@ stepFunctions:
     hfstepfuncdirectdebit:
       name: HFDirectDebitStateMachine
       events:
-        - schedule: cron(30 1 * * ? *)
+        - schedule: cron(30 2 * * ? *)
       definition:
         Comment: "Direct debit process step function deployed via serverless. Run at 01:30 AM"
         StartAt: ImportDirectDebit


### PR DESCRIPTION
# What:
 - Pushed back the `CashFile`, `DirectDebit`, and `adjustment-transactions` nightly processes by 1 hour.
 - Removed the Charges ingest step function process.

# Why:
 - So that the CashFile wouldn't overlap and wouldn't need to compete for DB resources with the spilling over Charges process _(which according to the nightly timeout was scheduled to run for 30min max, but is now running for ~1hour)_. Pushing back the CashFile requires pushing back of other processes following it.
 - Charges ingest process is being commented out as it was moved out into separate repository [[link](https://github.com/LBHackney-IT/HfsChargesContainer)]. The C# and yaml code will be kept for the time being as it was requested so.

# Notes:
 - The `adjustments-trans` process is not a step function, but rather a single lambda, which has a processing time timeout of 15 minutes. As such, time interval from `2:45AM - 3:00AM` should easily satisfy this step's worst case scenario.
 - See nightly job timeline documentation [[link](https://whimsical.com/hfs-batch-F7cxbsT8iGedvoKAX3bFjH)].
 - Informative process breakdown:

| ![image](https://github.com/LBHackney-IT/housing-finance-interim-api/assets/43747286/f8430007-6d4a-4dc1-b188-b09b4f52f05d) |
| ---------  |
| This table lists all of the process start times, changes to start times, and how long they take to run currently. The included dates are merely reference points from which run time was calculated. Took ~ May 24th as that was before database power upgrade. |