### PR TITLE
Refresh Operating Balance CW Alarm

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/RefreshOperatingBalanceUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/RefreshOperatingBalanceUseCaseTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HousingFinanceInterimApi.V1.Gateways.Interface;
+using HousingFinanceInterimApi.V1.UseCase;
+using HousingFinanceInterimApi.V1.UseCase.Interfaces;
+using Moq;
+using Xunit;
+
+namespace HousingFinanceInterimApi.Tests.V1.UseCase
+{
+    public class RefreshOperatingBalanceUseCaseTests
+    {
+        private Mock<IOperatingBalanceGateway> _mockOperatingBalanceGateway;
+        private IRefreshOperatingBalanceUseCase _classUnderTest;
+
+        public RefreshOperatingBalanceUseCaseTests()
+        {
+            _mockOperatingBalanceGateway = new Mock<IOperatingBalanceGateway>();
+            _classUnderTest = new RefreshOperatingBalanceUseCase(_mockOperatingBalanceGateway.Object);
+        }
+
+        [Fact]
+        public async Task ShouldGenerateOperatingBalanceAndReturnStepResponse()
+        {
+            // Arrange
+            var waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync().ConfigureAwait(true);
+
+            // Assert
+            result.Continue.Should().BeTrue();
+            result.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(int.Parse(waitDuration)));
+            _mockOperatingBalanceGateway.Verify(x => x.GenerateOperatingBalance(), Times.Once);
+        }
+
+        [Fact]
+        public void ShouldLogErrorAndRethrowExceptionIfGenerateOperatingBalanceThrowsException()
+        {
+            // Arrange
+            var exception = new Exception("Test exception");
+            _mockOperatingBalanceGateway.Setup(x => x.GenerateOperatingBalance()).ThrowsAsync(exception);
+
+            // Act
+            Func<Task> act = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(true);
+
+            // Assert
+            act.Should().Throw<Exception>().WithMessage(exception.Message);
+            _mockOperatingBalanceGateway.Verify(x => x.GenerateOperatingBalance(), Times.Once);
+        }
+    }
+}

--- a/HousingFinanceInterimApi/V1/UseCase/RefreshOperatingBalanceUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/RefreshOperatingBalanceUseCase.cs
@@ -1,10 +1,7 @@
 using System;
 using AutoMapper;
-using HousingFinanceInterimApi.V1.Domain;
-using HousingFinanceInterimApi.V1.Factories;
 using HousingFinanceInterimApi.V1.Gateways.Interface;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -649,7 +649,7 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-check-housing-files
-    RentPositionLambdaAlarm:
+    OperatingBalanceLambdaAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: "${self:provider.stage}-housing-finance-refresh-op-bal-lambda-alarm"
@@ -661,6 +661,7 @@ resources:
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
         Period: 60
+        TreatMissingData: notBreaching
         AlarmActions: 
           - 'Fn::Join':
             - ':'

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -649,6 +649,28 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-check-housing-files
+    RentPositionLambdaAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-housing-finance-refresh-op-bal-lambda-alarm"
+        AlarmDescription: Errors detected in AWS Lambda for Refresh Operating Balance function
+        Namespace: AWS/Lambda
+        MetricName: "Errors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        AlarmActions: 
+          - 'Fn::Join':
+            - ':'
+            - - 'arn:aws:sns'
+              - Ref: 'AWS::Region'
+              - Ref: 'AWS::AccountId'
+              - 'housing-finance-alarms'
+        Dimensions:
+          - Name: FunctionName
+            Value: ${self:service}-${self:provider.stage}-refresh-op-bal
 custom:
   vpc:
     development:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/POH-147

## Describe this PR

### *What changes have we introduced*

Add a cloudwatch alarm to alert devs when the Refresh Operating Balance lambda function fails.
