### PR TITLE
Add 'TreatMissingData' field to alarms

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -573,6 +573,7 @@ resources:
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
         Period: 60
+        TreatMissingData: notBreaching
         AlarmActions:
           - 'Fn::Join':
               - ':'
@@ -595,6 +596,7 @@ resources:
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
         Period: 60
+        TreatMissingData: notBreaching
         AlarmActions: 
           - 'Fn::Join':
             - ':'
@@ -617,6 +619,7 @@ resources:
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
         Period: 60
+        TreatMissingData: notBreaching
         AlarmActions: 
           - 'Fn::Join':
             - ':'
@@ -640,6 +643,7 @@ resources:
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
         Period: 60
+        TreatMissingData: notBreaching
         AlarmActions: 
           - 'Fn::Join':
             - ':'
@@ -663,6 +667,7 @@ resources:
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
         Period: 60
+        TreatMissingData: notBreaching
         AlarmActions: 
           - 'Fn::Join':
             - ':'


### PR DESCRIPTION
Currently, when no errors are detected in our lambdas, the alarms show 'insufficient data'. This should be tweaked to show 'not in alarm' if there is no data (i.e. no errors detected).