### PR TITLE
Cloudwatch Alarm - Direct Debit Transactions

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitTransactionsUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitTransactionsUseCaseTest.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HousingFinanceInterimApi.V1.Domain;
+using HousingFinanceInterimApi.V1.Gateways.Interface;
+using HousingFinanceInterimApi.V1.UseCase;
+using HousingFinanceInterimApi.V1.UseCase.Interfaces;
+using Moq;
+using Xunit;
+
+namespace HousingFinanceInterimApi.Tests.V1.UseCase
+{
+    public class LoadDirectDebitTransactionsUseCaseTest
+    {
+        private readonly Mock<IBatchLogGateway> _mockBatchLogGateway;
+        private readonly Mock<IBatchLogErrorGateway> _mockBatchLogErrorGateway;
+        private readonly Mock<IDirectDebitGateway> _mockDirectDebitGateway;
+        private readonly Mock<ITransactionGateway> _mockTransactionGateway;
+
+        private readonly ILoadDirectDebitTransactionsUseCase _classUnderTest;
+        private readonly double _waitDuration = 30;
+
+        public LoadDirectDebitTransactionsUseCaseTest()
+        {
+            Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
+
+            _mockBatchLogGateway = new Mock<IBatchLogGateway>();
+            _mockBatchLogErrorGateway = new Mock<IBatchLogErrorGateway>();
+            _mockDirectDebitGateway = new Mock<IDirectDebitGateway>();
+            _mockTransactionGateway = new Mock<ITransactionGateway>();
+
+            _classUnderTest = new LoadDirectDebitTransactionsUseCase(
+                _mockBatchLogGateway.Object,
+                _mockBatchLogErrorGateway.Object,
+                _mockDirectDebitGateway.Object,
+                _mockTransactionGateway.Object);
+
+            _mockBatchLogGateway
+                .Setup(x => x.CreateAsync(It.IsAny<string>(), false))
+                .ReturnsAsync(new BatchLogDomain { Id = 1 });
+        }
+
+        [Fact]
+        public async Task ExecuteAsyncShouldLoadDirectDebitTransactionsAndReturnStepResponse()
+        {
+            // Arrange
+            var processingDate = DateTime.UtcNow;
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync(processingDate).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Continue.Should().BeTrue();
+            result.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration));
+
+            _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
+            _mockTransactionGateway.Verify(x => x.LoadDirectDebitTransactions(), Times.Once);
+            _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteAsyncShouldCatchExceptionAndThrow()
+        {
+            // Arrange
+            var processingDate = DateTime.UtcNow;
+            var testException = new Exception("Test Exception");
+
+            _mockTransactionGateway
+                .Setup(x => x.LoadDirectDebitTransactions())
+                .ThrowsAsync(testException);
+
+            // Act + Assert
+            _classUnderTest.Invoking(x => x.ExecuteAsync(processingDate))
+                           .Should()
+                           .Throw<Exception>()
+                           .WithMessage(testException.Message);
+            _mockBatchLogErrorGateway.Verify(x => x.CreateAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public async Task ExecuteOnDemandAsyncShouldLoadDirectDebitTransactionsAndReturnStepResponse(int dayDifference)
+        {
+            // Arrange
+            var startDate = DateTime.Now.Date;
+            var endDate = startDate.AddDays(dayDifference);
+            var loopCount = dayDifference + 1;  // +1 because it includes the endDate
+
+            // Act
+            var result = await _classUnderTest.ExecuteOnDemandAsync(startDate, endDate).ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Continue.Should().BeTrue();
+            result.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration));
+
+            _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
+            _mockDirectDebitGateway.Verify(x => x.LoadDirectDebitHistory(It.IsAny<DateTime>()), Times.Exactly(loopCount));
+            _mockTransactionGateway.Verify(x => x.LoadDirectDebitTransactions(), Times.Exactly(loopCount));
+            _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteOnDemandAsyncShouldCatchExceptionAndThrow()
+        {
+            // Arrange
+            var startDate = DateTime.UtcNow.Date;
+            var endDate = startDate.AddDays(1);
+            var testException = new Exception("Test Exception");
+
+            _mockDirectDebitGateway
+                .Setup(x => x.LoadDirectDebitHistory(startDate))
+                .ThrowsAsync(testException);
+
+            // Act
+            _classUnderTest.Invoking(x => x.ExecuteOnDemandAsync(startDate, endDate))
+                           .Should()
+                           .Throw<Exception>()
+                           .WithMessage(testException.Message);
+            _mockBatchLogErrorGateway.Verify(x => x.CreateAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitTransactionsUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitTransactionsUseCase.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using HousingFinanceInterimApi.V1.Domain;
-using HousingFinanceInterimApi.V1.Factories;
 using HousingFinanceInterimApi.V1.Gateways.Interface;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using System.Threading.Tasks;
-using Google.Apis.Drive.v3.Data;
 using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;
 

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -722,29 +722,6 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-refresh-op-bal
-    ImportDirectDebitAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Properties:
-        AlarmName: "${self:provider.stage}-housing-finance-direct-debit-lambda-alarm"
-        AlarmDescription: Errors detected in AWS Lambda for Import Direct Debit function
-        Namespace: AWS/Lambda
-        MetricName: "Errors"
-        Statistic: Sum
-        Threshold: 0
-        ComparisonOperator: GreaterThanThreshold
-        EvaluationPeriods: 1
-        Period: 60
-        TreatMissingData: notBreaching
-        AlarmActions: 
-          - 'Fn::Join':
-            - ':'
-            - - 'arn:aws:sns'
-              - Ref: 'AWS::Region'
-              - Ref: 'AWS::AccountId'
-              - 'housing-finance-alarms'
-        Dimensions:
-          - Name: FunctionName
-            Value: ${self:service}-${self:provider.stage}-direct-debit
     ImportDirectDebitTransactionsAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -699,7 +699,53 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-check-housing-files
-custom:
+    ImportDirectDebitAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-housing-finance-direct-debit-lambda-alarm"
+        AlarmDescription: Errors detected in AWS Lambda for Import Direct Debit function
+        Namespace: AWS/Lambda
+        MetricName: "Errors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions: 
+          - 'Fn::Join':
+            - ':'
+            - - 'arn:aws:sns'
+              - Ref: 'AWS::Region'
+              - Ref: 'AWS::AccountId'
+              - 'housing-finance-alarms'
+        Dimensions:
+          - Name: FunctionName
+            Value: ${self:service}-${self:provider.stage}-direct-debit
+    ImportDirectDebitTransactionsAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-housing-financedirect-debit-trans-alarm"
+        AlarmDescription: Errors detected in AWS Lambda for Import Direct Debit Transactions function
+        Namespace: AWS/Lambda
+        MetricName: "Errors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions: 
+          - 'Fn::Join':
+            - ':'
+            - - 'arn:aws:sns'
+              - Ref: 'AWS::Region'
+              - Ref: 'AWS::AccountId'
+              - 'housing-finance-alarms'
+        Dimensions:
+          - Name: FunctionName
+            Value: ${self:service}-${self:provider.stage}-direct-debit-trans
+      
   vpc:
     development:
       securityGroupIds:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -510,7 +510,7 @@ stepFunctions:
       dependsOn: lambdaExecutionRole
       tags:
         Team: HousingFinance
-resources:  
+resources:
   Resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role
@@ -722,7 +722,7 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-susp-hb
-  importCashFileTransactionsAlarm:
+    ImportCashFileTransactionsAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: "${self:provider.stage}-cash-file-trans-alarm"
@@ -744,8 +744,7 @@ resources:
               - 'housing-finance-alarms'
         Dimensions:
           - Name: FunctionName
-            Value: ${self:service}-${self:provider.stage}-cash-file-trans
-          
+            Value: ${self:service}-${self:provider.stage}-cash-file-trans        
     OperatingBalanceLambdaAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/POH-140

## Describe this PR

### *What is the problem we're trying to solve*

We currently do not receive notifications for the failure of many of the HFS processes, and we don’t have indicators that something may have gone wrong with the process.

### *What changes have we introduced*

- Add a cloudwatch alarm to alert devs when it fails
- Add unit tests which were missing

