### PR TITLE
Add self as codeowner.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @LBHSPreston @FaisalHackney @LBHackney-IT/mtfh-finance
+* @LBHSPreston @FaisalHackney @Duslerke @LBHackney-IT/mtfh-finance


### PR DESCRIPTION
# What:
 - Add myself as Code Owner.

# Why:
 - So the burden of PR approval doesn't fall on one person.
