### PR TITLE
Cloudwatch Alarm - Load Direct Debit

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
@@ -8,6 +8,9 @@ using HousingFinanceInterimApi.V1.UseCase;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using Moq;
 using Xunit;
+using AutoFixture;
+using System.Linq;
+using HousingFinanceInterimApi.V1.Exceptions;
 
 namespace HousingFinanceInterimApi.Tests.V1.UseCase
 {
@@ -19,11 +22,14 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
         private readonly Mock<IGoogleClientService> _mockGoogleClientService;
 
+        private readonly Fixture _fixture = new();
         private readonly ILoadDirectDebitUseCase _classUnderTest;
+
         private readonly double _waitDuration = 30;
         private readonly string _directDebitLabel = "DirectDebit";
         private readonly string _sheetId = "google_identifier";
-
+        private readonly string[] _sheetNames = "Rent;LH".Split(";");
+        private readonly string _sheetRange = "A:C";
         public LoadDirectDebitUseCaseTest()
         {
             Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
@@ -47,8 +53,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             
             var googleFileSettings = new List<GoogleFileSettingDomain>
             {
-                new() {
-                }
+                new() { GoogleIdentifier = _sheetId }
             };
 
             _mockGoogleFileSettingGateway
@@ -56,18 +61,16 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(googleFileSettings);
         }
 
+
         [Fact]
         public async Task ExecuteAsyncShouldLoadDirectDebitsAndReturnStepResponse()
         {
             // Arrange
-            const string sheetNames = "Rent;LH";
-            const string sheetRange = "A:C";
-
-            var sheetCount = sheetNames.Split(";").Length;
-            var directDebits = new List<DirectDebitAuxDomain>();
+            var sheetCount = _sheetNames.Length;
+            var directDebits = _fixture.CreateMany<DirectDebitAuxDomain>(10).ToList();
             
             _mockGoogleClientService
-                .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsAny<string>(), sheetRange))
+                .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsAny<string>(), _sheetRange))
                 .ReturnsAsync(directDebits);
 
             // Act
@@ -80,67 +83,81 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
             _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
-
-            _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn<string>("Rent", "LH"), sheetRange),
+  
+            _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn<string>("Rent", "LH"), _sheetRange),
                                             Times.Exactly(sheetCount));
             _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Exactly(sheetCount));
             _mockDirectDebitGateway.Verify(x => x.CreateBulkAsync(directDebits), Times.Exactly(sheetCount));
             _mockDirectDebitGateway.Verify(x => x.LoadDirectDebit(It.IsAny<long>()), Times.Exactly(sheetCount));
+
             _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
         }
 
-        // [Fact]
-        // public void ExecuteAsyncShouldCatchExceptionAndThrow()
-        // {
-        //     // Arrange
-        //     var testException = new Exception("Test Exception");
+        [Fact]
+        public async Task ExecuteAsyncShouldContinueWhenNoDirectDebits()
+        {
+            // Arrange
+            var sheetCount = _sheetNames.Length;
+            var directDebits = new List<DirectDebitAuxDomain>();
+            
+            _mockGoogleClientService
+                .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn(_sheetNames), _sheetRange))
+                .ReturnsAsync(directDebits);
+            
+            // Act
+            var result = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-        //     _mockGoogleFileSettingGateway
-        //         .Setup(x => x.GetSettingsByLabel(It.IsAny<string>()))
-        //         .ThrowsAsync(testException);
+            // Assert
+            result.Should().NotBeNull();
+            result.Continue.Should().BeTrue();
+            result.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration));
 
-        //     // Act + Assert
-        //     _classUnderTest.Invoking(x => x.ExecuteAsync())
-        //                    .Should()
-        //                    .Throw<GoogleFileSettingNotFoundException>()
-        //                    .WithMessage($"Google file setting not found for '{LoadDirectDebitUseCase.DirectDebitLabel}' label");
-        //     _mockBatchLogErrorGateway.Verify(x => x.CreateAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-        // }
+            _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
+            _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
+  
+            _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn(_sheetNames), _sheetRange),
+                                            Times.Exactly(sheetCount));
+            _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Never);
+            _mockDirectDebitGateway.Verify(x => x.CreateBulkAsync(directDebits), Times.Never);
+            _mockDirectDebitGateway.Verify(x => x.LoadDirectDebit(It.IsAny<long>()), Times.Never);
 
-        // [Fact]
-        // public void ExecuteAsyncShouldCatchExceptionAndThrowWhenNoDirectDebits()
-        // {
-        //     // Arrange
-        //     const string sheetNames = "Rent;LH";
-        //     const string sheetRange = "A:C";
-        //     var googleFileSettings = new List<GoogleFileSettingDomain>
-        //     {
-        //         new GoogleFileSettingDomain
-        //         {
-        //             GoogleIdentifier = "google_identifier"
-        //         }
-        //     };
-        //     var directDebits = new List<DirectDebitAuxDomain>();
+            _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
+        }
 
-        //     _mockGoogleFileSettingGateway
-        //         .Setup(x => x.GetSettingsByLabel(It.IsAny<string>()))
-        //         .ReturnsAsync(googleFileSettings);
+        [Fact]
+        public void ExecuteAsyncShouldCatchExceptionAndThrow()
+        {
+            // Arrange
+            var testException = new Exception("Test Exception");
 
-        //     _mockGoogleClientService
-        //         .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-        //         .ReturnsAsync(directDebits);
+            _mockBatchLogGateway
+                .Setup(x => x.CreateAsync(It.IsAny<string>(), false))
+                .ThrowsAsync(testException);
 
-        //     // Act + Assert
-        //     _classUnderTest.Invoking(x => x.ExecuteAsync())
-        //                    .Should()
-        //                    .NotThrow();
-        //     _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>()), Times.Once);
-        //     _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
-        //     _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(sheetNames.Split(";").Length));
-        //     _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Never);
-        //     _mockDirectDebitGateway.Verify(x => x.CreateBulkAsync(directDebits), Times.Never);
-        //     _mockDirectDebitGateway.Verify(x => x.LoadDirectDebit(It.IsAny<long>()), Times.Never);
-        //     _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
-        // }
+            // Act + Assert
+            _classUnderTest.Invoking(x => x.ExecuteAsync())
+                           .Should()
+                           .Throw<Exception>()
+                           .WithMessage(testException.Message);
+            _mockBatchLogErrorGateway.Verify(x => x.CreateAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteAsyncShouldThrowIfGoogleFileSettingsNotFound()
+        {
+            // Arrange
+            var googleFileSettings = new List<GoogleFileSettingDomain>();
+            var directDebits = _fixture.CreateMany<DirectDebitAuxDomain>(10).ToList();
+
+            _mockGoogleFileSettingGateway
+                .Setup(x => x.GetSettingsByLabel(_directDebitLabel))
+                .ReturnsAsync(googleFileSettings);
+
+            // Act + Assert
+            _classUnderTest.Invoking(x => x.ExecuteAsync())
+                           .Should()
+                           .Throw<GoogleFileSettingNotFoundException>()
+                           .WithMessage($"No Google File Settings found with label: {_directDebitLabel}.");
+        }
     }
 }

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HousingFinanceInterimApi.V1.Domain;
+using HousingFinanceInterimApi.V1.Gateways.Interface;
+using HousingFinanceInterimApi.V1.UseCase;
+using HousingFinanceInterimApi.V1.UseCase.Interfaces;
+using Moq;
+using Xunit;
+
+namespace HousingFinanceInterimApi.Tests.V1.UseCase
+{
+    public class LoadDirectDebitUseCaseTest
+    {
+        private readonly Mock<IBatchLogGateway> _mockBatchLogGateway;
+        private readonly Mock<IBatchLogErrorGateway> _mockBatchLogErrorGateway;
+        private readonly Mock<IDirectDebitGateway> _mockDirectDebitGateway;
+        private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
+        private readonly Mock<IGoogleClientService> _mockGoogleClientService;
+
+        private readonly ILoadDirectDebitUseCase _classUnderTest;
+        private readonly double _waitDuration = 30;
+        private readonly string _directDebitLabel = "DirectDebit";
+        private readonly string _sheetId = "google_identifier";
+
+        public LoadDirectDebitUseCaseTest()
+        {
+            Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
+
+            _mockBatchLogGateway = new Mock<IBatchLogGateway>();
+            _mockBatchLogErrorGateway = new Mock<IBatchLogErrorGateway>();
+            _mockDirectDebitGateway = new Mock<IDirectDebitGateway>();
+            _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
+            _mockGoogleClientService = new Mock<IGoogleClientService>();
+
+            _classUnderTest = new LoadDirectDebitUseCase(
+                _mockBatchLogGateway.Object,
+                _mockBatchLogErrorGateway.Object,
+                _mockDirectDebitGateway.Object,
+                _mockGoogleFileSettingGateway.Object,
+                _mockGoogleClientService.Object);
+
+            _mockBatchLogGateway
+                .Setup(x => x.CreateAsync(It.IsAny<string>(), false))
+                .ReturnsAsync(new BatchLogDomain { Id = 1 });
+            
+            var googleFileSettings = new List<GoogleFileSettingDomain>
+            {
+                new() {
+                }
+            };
+
+            _mockGoogleFileSettingGateway
+                .Setup(x => x.GetSettingsByLabel(_directDebitLabel))
+                .ReturnsAsync(googleFileSettings);
+        }
+
+        [Fact]
+        public async Task ExecuteAsyncShouldLoadDirectDebitsAndReturnStepResponse()
+        {
+            // Arrange
+            const string sheetNames = "Rent;LH";
+            const string sheetRange = "A:C";
+
+            var sheetCount = sheetNames.Split(";").Length;
+            var directDebits = new List<DirectDebitAuxDomain>();
+            
+            _mockGoogleClientService
+                .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsAny<string>(), sheetRange))
+                .ReturnsAsync(directDebits);
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Continue.Should().BeTrue();
+            result.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration));
+
+            _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
+            _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
+
+            _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn<string>("Rent", "LH"), sheetRange),
+                                            Times.Exactly(sheetCount));
+            _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Exactly(sheetCount));
+            _mockDirectDebitGateway.Verify(x => x.CreateBulkAsync(directDebits), Times.Exactly(sheetCount));
+            _mockDirectDebitGateway.Verify(x => x.LoadDirectDebit(It.IsAny<long>()), Times.Exactly(sheetCount));
+            _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
+        }
+
+        // [Fact]
+        // public void ExecuteAsyncShouldCatchExceptionAndThrow()
+        // {
+        //     // Arrange
+        //     var testException = new Exception("Test Exception");
+
+        //     _mockGoogleFileSettingGateway
+        //         .Setup(x => x.GetSettingsByLabel(It.IsAny<string>()))
+        //         .ThrowsAsync(testException);
+
+        //     // Act + Assert
+        //     _classUnderTest.Invoking(x => x.ExecuteAsync())
+        //                    .Should()
+        //                    .Throw<GoogleFileSettingNotFoundException>()
+        //                    .WithMessage($"Google file setting not found for '{LoadDirectDebitUseCase.DirectDebitLabel}' label");
+        //     _mockBatchLogErrorGateway.Verify(x => x.CreateAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        // }
+
+        // [Fact]
+        // public void ExecuteAsyncShouldCatchExceptionAndThrowWhenNoDirectDebits()
+        // {
+        //     // Arrange
+        //     const string sheetNames = "Rent;LH";
+        //     const string sheetRange = "A:C";
+        //     var googleFileSettings = new List<GoogleFileSettingDomain>
+        //     {
+        //         new GoogleFileSettingDomain
+        //         {
+        //             GoogleIdentifier = "google_identifier"
+        //         }
+        //     };
+        //     var directDebits = new List<DirectDebitAuxDomain>();
+
+        //     _mockGoogleFileSettingGateway
+        //         .Setup(x => x.GetSettingsByLabel(It.IsAny<string>()))
+        //         .ReturnsAsync(googleFileSettings);
+
+        //     _mockGoogleClientService
+        //         .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+        //         .ReturnsAsync(directDebits);
+
+        //     // Act + Assert
+        //     _classUnderTest.Invoking(x => x.ExecuteAsync())
+        //                    .Should()
+        //                    .NotThrow();
+        //     _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>()), Times.Once);
+        //     _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
+        //     _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(sheetNames.Split(";").Length));
+        //     _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Never);
+        //     _mockDirectDebitGateway.Verify(x => x.CreateBulkAsync(directDebits), Times.Never);
+        //     _mockDirectDebitGateway.Verify(x => x.LoadDirectDebit(It.IsAny<long>()), Times.Never);
+        //     _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(It.IsAny<long>()), Times.Once);
+        // }
+    }
+}

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
@@ -50,7 +50,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             _mockBatchLogGateway
                 .Setup(x => x.CreateAsync(It.IsAny<string>(), false))
                 .ReturnsAsync(new BatchLogDomain { Id = 1 });
-            
+
             var googleFileSettings = new List<GoogleFileSettingDomain>
             {
                 new() { GoogleIdentifier = _sheetId }
@@ -68,7 +68,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // Arrange
             var sheetCount = _sheetNames.Length;
             var directDebits = _fixture.CreateMany<DirectDebitAuxDomain>(10).ToList();
-            
+
             _mockGoogleClientService
                 .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsAny<string>(), _sheetRange))
                 .ReturnsAsync(directDebits);
@@ -83,7 +83,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
             _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
-  
+
             _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn<string>("Rent", "LH"), _sheetRange),
                                             Times.Exactly(sheetCount));
             _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Exactly(sheetCount));
@@ -99,11 +99,11 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // Arrange
             var sheetCount = _sheetNames.Length;
             var directDebits = new List<DirectDebitAuxDomain>();
-            
+
             _mockGoogleClientService
                 .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn(_sheetNames), _sheetRange))
                 .ReturnsAsync(directDebits);
-            
+
             // Act
             var result = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
@@ -114,7 +114,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
 
             _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
             _mockGoogleFileSettingGateway.Verify(x => x.GetSettingsByLabel(It.IsAny<string>()), Times.Once);
-  
+
             _mockGoogleClientService.Verify(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsIn(_sheetNames), _sheetRange),
                                             Times.Exactly(sheetCount));
             _mockDirectDebitGateway.Verify(x => x.ClearDirectDebitAuxiliary(), Times.Never);

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/LoadDirectDebitUseCaseTest.cs
@@ -128,10 +128,15 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         public void ExecuteAsyncShouldCatchExceptionAndThrow()
         {
             // Arrange
+            var directDebits = _fixture.CreateMany<DirectDebitAuxDomain>(10).ToList();
+            _mockGoogleClientService
+                .Setup(x => x.ReadSheetToEntitiesAsync<DirectDebitAuxDomain>(_sheetId, It.IsAny<string>(), _sheetRange))
+                .ReturnsAsync(directDebits);
+
             var testException = new Exception("Test Exception");
 
-            _mockBatchLogGateway
-                .Setup(x => x.CreateAsync(It.IsAny<string>(), false))
+            _mockDirectDebitGateway
+                .Setup(x => x.ClearDirectDebitAuxiliary())
                 .ThrowsAsync(testException);
 
             // Act + Assert

--- a/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitUseCase.cs
@@ -2,14 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HousingFinanceInterimApi.V1.Domain;
-using HousingFinanceInterimApi.V1.Factories;
 using HousingFinanceInterimApi.V1.Gateways.Interface;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using System.Threading.Tasks;
-using Google.Apis.Drive.v3.Data;
 using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;
-using HousingFinanceInterimApi.V1.Infrastructure;
+using HousingFinanceInterimApi.V1.Exceptions;
 
 namespace HousingFinanceInterimApi.V1.UseCase
 {
@@ -47,10 +45,8 @@ namespace HousingFinanceInterimApi.V1.UseCase
             const string sheetRange = "A:C";
 
             var batch = await _batchLogGateway.CreateAsync(DirectDebitLabel).ConfigureAwait(false);
-            var googleFileSettings = await GetGoogleFileSetting(DirectDebitLabel).ConfigureAwait(false);
-
-            if (googleFileSettings == null)
-                return new StepResponse() { Continue = false, NextStepTime = DateTime.Now.AddSeconds(0) };
+            var googleFileSettings = await GetGoogleFileSetting(DirectDebitLabel).ConfigureAwait(false)
+                                      ?? throw new GoogleFileSettingNotFoundException($"Google file setting not found for '{DirectDebitLabel}' label");
 
             foreach (var sheetName in sheetNames.Split(";"))
             {

--- a/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitUseCase.cs
@@ -46,7 +46,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
 
             var batch = await _batchLogGateway.CreateAsync(DirectDebitLabel).ConfigureAwait(false);
             var googleFileSettings = await GetGoogleFileSetting(DirectDebitLabel).ConfigureAwait(false)
-                                      ?? throw new GoogleFileSettingNotFoundException($"Google file setting not found for '{DirectDebitLabel}' label");
+                                      ?? throw new GoogleFileSettingNotFoundException(DirectDebitLabel);
 
             foreach (var sheetName in sheetNames.Split(";"))
             {

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -722,6 +722,29 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-susp-hb
+    ImportDirectDebitAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-housing-finance-direct-debit-lambda-alarm"
+        AlarmDescription: Errors detected in AWS Lambda for Import Direct Debit function
+        Namespace: AWS/Lambda
+        MetricName: "Errors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions: 
+          - 'Fn::Join':
+            - ':'
+            - - 'arn:aws:sns'
+              - Ref: 'AWS::Region'
+              - Ref: 'AWS::AccountId'
+              - 'housing-finance-alarms'
+        Dimensions:
+          - Name: FunctionName
+            Value: ${self:service}-${self:provider.stage}-direct-debit
     OperatingBalanceLambdaAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/POH-140

## Describe this PR

### *What is the problem we're trying to solve*

We currently do not receive notifications for the failure of many of the HFS processes, and we don’t have indicators that something may have gone wrong with the process.

### *What changes have we introduced*

- Add a cloudwatch alarm to alert devs when it fails
- Add unit tests which were missing

