### PR TITLE
CW Alarm - Housing File Transactions

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/LoadHousingFileTransactionsUseCaseTest.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/LoadHousingFileTransactionsUseCaseTest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HousingFinanceInterimApi.V1.Domain;
+using HousingFinanceInterimApi.V1.Gateways.Interface;
+using HousingFinanceInterimApi.V1.UseCase;
+using HousingFinanceInterimApi.V1.UseCase.Interfaces;
+using Moq;
+using Xunit;
+
+namespace HousingFinanceInterimApi.Tests.V1.UseCase
+{
+    public class LoadHousingFileTransactionsUseCaseTests
+    {
+        private readonly Mock<IBatchLogGateway> _mockBatchLogGateway = new();
+        private readonly Mock<IBatchLogErrorGateway> _mockBatchLogErrorGateway = new();
+        private readonly Mock<IUPHousingCashLoadGateway> _mockUpHousingCashLoadGateway = new();
+        private readonly Mock<ITransactionGateway> _mockTransactionGateway = new();
+        private readonly ILoadHousingFileTransactionsUseCase _classUnderTest;
+
+        public LoadHousingFileTransactionsUseCaseTests()
+        {
+            _classUnderTest = new LoadHousingFileTransactionsUseCase(
+                _mockBatchLogGateway.Object,
+                _mockBatchLogErrorGateway.Object,
+                _mockUpHousingCashLoadGateway.Object,
+                _mockTransactionGateway.Object);
+        }
+
+        [Fact]
+        public async Task ShouldLoadHousingFilesAndReturnStepResponse()
+        {
+            // Arrange
+            var waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
+            var batchId = 1;
+            _mockBatchLogGateway.Setup(x => x.CreateAsync(It.IsAny<string>(), false))
+                                .ReturnsAsync(new BatchLogDomain { Id = batchId });
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync().ConfigureAwait(true);
+
+            // Assert
+            result.Continue.Should().BeTrue();
+            result.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(int.Parse(waitDuration)));
+            
+            _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
+            _mockUpHousingCashLoadGateway.Verify(x => x.LoadHousingFiles(), Times.Once);
+            _mockTransactionGateway.Verify(x => x.LoadHousingFilesTransactions(), Times.Once);
+            _mockBatchLogGateway.Verify(x => x.SetToSuccessAsync(batchId), Times.Once);
+        }
+
+        [Fact]
+        public void ShouldLogErrorAndRethrowExceptionIfLoadHousingFilesThrowsException()
+        {
+            // Arrange
+            var exception = new Exception("Test exception");
+            _mockUpHousingCashLoadGateway.Setup(x => x.LoadHousingFiles()).ThrowsAsync(exception);
+
+            // Act
+            Func<Task> act = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(true);
+
+            // Assert
+            act.Should().Throw<Exception>().WithMessage(exception.Message);
+            _mockBatchLogGateway.Verify(x => x.CreateAsync(It.IsAny<string>(), false), Times.Once);
+            _mockBatchLogErrorGateway.Verify(x => x.CreateAsync(It.IsAny<long>(), "ERROR", "Application error. Not possible to load housing files transactions"),
+                                             Times.Once);
+        }
+    }
+}

--- a/HousingFinanceInterimApi/V1/UseCase/LoadHousingFileTransactionsUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadHousingFileTransactionsUseCase.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using HousingFinanceInterimApi.V1.Domain;
-using HousingFinanceInterimApi.V1.Factories;
 using HousingFinanceInterimApi.V1.Gateways.Interface;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using System.Threading.Tasks;
-using Google.Apis.Drive.v3.Data;
 using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;
 

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -699,7 +699,7 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-check-housing-files
-  SuspenseHousingBenefitLambdaAlarm:
+    SuspenseHousingBenefitLambdaAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: "${self:provider.stage}-susp-hb-lambda-alarm"
@@ -722,7 +722,7 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-susp-hb
-  OperatingBalanceLambdaAlarm:
+    OperatingBalanceLambdaAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: "${self:provider.stage}-housing-finance-refresh-op-bal-lambda-alarm"
@@ -745,6 +745,29 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-refresh-op-bal
+    HousingFileTransactionsLambdaAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-housing-file-trans-lambda-alarm"
+        AlarmDescription: Errors detected in AWS Lambda for Import Housing Files Transactions function
+        Namespace: AWS/Lambda
+        MetricName: "Errors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions: 
+          - 'Fn::Join':
+            - ':'
+            - - 'arn:aws:sns'
+              - Ref: 'AWS::Region'
+              - Ref: 'AWS::AccountId'
+              - 'housing-finance-alarms'
+        Dimensions:
+          - Name: FunctionName
+            Value: ${self:service}-${self:provider.stage}-housing-file-trans
 custom:
   vpc:
     development:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/POH-145

## Describe this PR

### *What is the problem we're trying to solve*

We currently do not receive notifications for the failure of many of the HFS processes, and we don’t have indicators that something may have gone wrong with the process.

### *What changes have we introduced*

- Add a cloudwatch alarm to alert devs when it fails
- Add unit tests which were missing

