### PR TITLE
Improve test runtime

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -20,6 +20,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
         private readonly Mock<IGoogleClientService> _mockGoogleClientService;
         private readonly int _waitDuration = 30;
+        private readonly int _sleepDuration = 1;
         private readonly IGenerateReportUseCase _classUnderTest;
 
         public GenerateReportUseCaseTests()
@@ -30,6 +31,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             _mockGoogleClientService = new Mock<IGoogleClientService>();
 
             Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
+            Environment.SetEnvironmentVariable("SLEEP_DURATION", _sleepDuration.ToString());
 
             _classUnderTest = new GenerateReportUseCase(
                     _mockBatchReportGateway.Object,
@@ -1635,7 +1637,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         }
 
         [Fact]
-        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpentConfigurdSecondsDoingIt()
         {
             // arrange
             var requestedReportLabel = "ReportItemisedTransactions";
@@ -1678,7 +1680,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(true);
 
             var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int expectedNumberOfFileRetrievalAttempts = 30; //RandomGen.WholeNumber(1, 30);
+            int expectedNumberOfFileRetrievalAttempts = _sleepDuration; //RandomGen.WholeNumber(1, 30);
             int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
             var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
             GD.File fileReturnedFromGDrive = null;
@@ -1709,7 +1711,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         }
 
         [Fact]
-        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
+        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpendingConfiguredSecondsDoingIt()
         {
             // arrange
             var requestedReportLabel = "ReportItemisedTransactions";
@@ -1752,7 +1754,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(true);
 
             var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int cutOffForNumberOfAttempts = 30;
+            int cutOffForNumberOfAttempts = _sleepDuration;
             DateTime? firstAttempt = null;
             DateTime lastAttempt = DateTime.MinValue;
             GD.File fileReturnedFromGDrive = null;

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -20,7 +20,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
         private readonly Mock<IGoogleClientService> _mockGoogleClientService;
         private readonly int _waitDuration = 30;
-        private readonly int _sleepDuration = 1;
+        private readonly int _sleepDuration = 1000; // in milliseconds
         private readonly IGenerateReportUseCase _classUnderTest;
 
         public GenerateReportUseCaseTests()
@@ -1680,7 +1680,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(true);
 
             var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int expectedNumberOfFileRetrievalAttempts = _sleepDuration; //RandomGen.WholeNumber(1, 30);
+            int expectedNumberOfFileRetrievalAttempts = _sleepDuration / 1000; // Convert to seconds //RandomGen.WholeNumber(1, 30);
             int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
             var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
             GD.File fileReturnedFromGDrive = null;
@@ -1754,7 +1754,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(true);
 
             var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int cutOffForNumberOfAttempts = _sleepDuration;
+            int cutOffForNumberOfAttempts = _sleepDuration / 1000; // Convert to seconds
             DateTime? firstAttempt = null;
             DateTime lastAttempt = DateTime.MinValue;
             GD.File fileReturnedFromGDrive = null;

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -24,7 +24,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
         private readonly IGoogleClientService _googleClientService;
 
         private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
-        private readonly int _sleepDuration = 30000;
+        private readonly int _sleepDuration = int.Parse(Environment.GetEnvironmentVariable("SLEEP_DURATION"));
 
         private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
         private const string ReportChargesLabel = "ReportCharges";

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HousingFinanceInterimApi.V1.Domain;
-using HousingFinanceInterimApi.V1.Factories;
 using HousingFinanceInterimApi.V1.Gateways.Interface;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using System.Threading.Tasks;

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -18,6 +18,7 @@ provider:
     CONNECTION_STRING: Data Source=${ssm:/housing-finance/${self:provider.stage}/db-host},${ssm:/housing-finance/${self:provider.stage}/db-port};Initial Catalog=${ssm:/housing-finance/${self:provider.stage}/db-database};Integrated Security=False;User Id=${ssm:/housing-finance/${self:provider.stage}/db-username};Password=${ssm:/housing-finance/${self:provider.stage}/db-password};Encrypt=False;TrustServerCertificate=False;MultipleActiveResultSets=True;
     GOOGLE_API_KEY: ${ssm:/housing-finance/${self:provider.stage}/google-application-credentials-json}
     WAIT_DURATION: ${ssm:/housing-finance/${self:provider.stage}/step-function-wait-duration}
+    SLEEP_DURATION: ${ssm:/housing-finance/${self:provider.stage}/report-generation-sleep-duration}
     BATCH_SIZE: ${ssm:/housing-finance/${self:provider.stage}/bulk-insert-batch-size}
     CASH_FILE_REGEX: ${ssm:/housing-finance/${self:provider.stage}/cash-file-regex}
     HOUSING_FILE_REGEX: ${ssm:/housing-finance/${self:provider.stage}/housing-benefit-file-regex}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*
Currently, the tests take 15 minutes to run, which makes development slow down as devs don't have a quick feedback loop.

### *What changes have we introduced*

Update `GenerateReportUseCase` to use an environment variable called `sleep_duration`. This will be set to 30 seconds in live environments, but only 1 second in the unit tests. This will reduce test runtime from 15 minutes to around 3 minutes.

