### PR TITLE
Fix Null Reference exception encountered when batch is null upon orig…

### DIFF
--- a/HousingFinanceInterimApi/V1/Gateways/BatchLogErrorGateway.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/BatchLogErrorGateway.cs
@@ -20,14 +20,19 @@ namespace HousingFinanceInterimApi.V1.Gateways
             _context = context;
         }
 
-        public async Task<BatchLogErrorDomain> CreateAsync(long batchId, string type, string message)
+        public async Task<BatchLogErrorDomain> CreateAsync(long? batchId, string type, string message)
         {
             try
             {
+                long concreteBatchId = batchId.HasValue ? batchId.Value : -1;
+
+                if (!batchId.HasValue)
+                    message += "\n'batchId' is missing.";
+
                 var newBatchError = new BatchLogError()
                 {
                     Type = type,
-                    BatchLogId = batchId,
+                    BatchLogId = concreteBatchId,
                     Message = message
                 };
                 await _context.BatchLogErrors.AddAsync(newBatchError).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/V1/Gateways/Interface/IBatchLogErrorGateway.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/Interface/IBatchLogErrorGateway.cs
@@ -6,7 +6,7 @@ namespace HousingFinanceInterimApi.V1.Gateways.Interface
 {
     public interface IBatchLogErrorGateway
     {
-        public Task<BatchLogErrorDomain> CreateAsync(long batchId, string type, string message);
+        public Task<BatchLogErrorDomain> CreateAsync(long? batchId, string type, string message);
 
         public Task<IList<BatchLogErrorDomain>> ListLastMonthAsync();
     }

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateRentPositionUseCase.cs
@@ -141,7 +141,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             {
                 var namespaceLabel = $"{nameof(HousingFinanceInterimApi)}.{nameof(Handler)}.{nameof(ExecuteAsync)}";
 
-                await _batchLogErrorGateway.CreateAsync(batch.Id, _rentPositionLabel, $"Application error. Not possible to generate rent position csv file").ConfigureAwait(false);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, _rentPositionLabel, $"Application error. Not possible to generate rent position csv file").ConfigureAwait(false);
 
                 LoggingHandler.LogError($"{namespaceLabel} Application error");
                 LoggingHandler.LogError(exc.ToString());

--- a/HousingFinanceInterimApi/V1/UseCase/LoadCashFileTransactionsUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadCashFileTransactionsUseCase.cs
@@ -53,7 +53,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             {
                 var namespaceLabel = $"{nameof(HousingFinanceInterimApi)}.{nameof(Handler)}.{nameof(ExecuteAsync)}";
 
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", $"Application error. Not possible to load cash files transactions").ConfigureAwait(false);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", $"Application error. Not possible to load cash files transactions").ConfigureAwait(false);
 
                 LoggingHandler.LogError($"{namespaceLabel} Application error");
                 LoggingHandler.LogError(exc.ToString());

--- a/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitTransactionsUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadDirectDebitTransactionsUseCase.cs
@@ -51,7 +51,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             {
                 var namespaceLabel = $"{nameof(HousingFinanceInterimApi)}.{nameof(Handler)}.{nameof(ExecuteAsync)}";
 
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", $"Application error. Not possible to load direct debit transactions").ConfigureAwait(false);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", $"Application error. Not possible to load direct debit transactions").ConfigureAwait(false);
 
                 LoggingHandler.LogError($"{namespaceLabel} Application error");
                 LoggingHandler.LogError(exc.ToString());
@@ -89,7 +89,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             {
                 var namespaceLabel = $"{nameof(HousingFinanceInterimApi)}.{nameof(Handler)}.{nameof(ExecuteAsync)}";
 
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", $"Application error. Not possible to load direct debit transactions on demand").ConfigureAwait(false);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", $"Application error. Not possible to load direct debit transactions on demand").ConfigureAwait(false);
 
                 LoggingHandler.LogError($"{namespaceLabel} Application error");
                 LoggingHandler.LogError(exc.ToString());

--- a/HousingFinanceInterimApi/V1/UseCase/LoadHousingFileTransactionsUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/LoadHousingFileTransactionsUseCase.cs
@@ -53,7 +53,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             {
                 var namespaceLabel = $"{nameof(HousingFinanceInterimApi)}.{nameof(Handler)}.{nameof(ExecuteAsync)}";
 
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", $"Application error. Not possible to load housing files transactions").ConfigureAwait(false);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", $"Application error. Not possible to load housing files transactions").ConfigureAwait(false);
 
                 LoggingHandler.LogError($"{namespaceLabel} application error");
                 LoggingHandler.LogError(exc.ToString());

--- a/HousingFinanceInterimApi/V1/UseCase/MoveHousingBenefitFileUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/MoveHousingBenefitFileUseCase.cs
@@ -139,19 +139,19 @@ namespace HousingFinanceInterimApi.V1.UseCase
             catch (GoogleApiException ex)
             {
                 LoggingHandler.LogError(ex.Message);
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", ex.Message);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", ex.Message);
                 throw;
             }
             catch (SIO.FileNotFoundException ex)
             {
                 LoggingHandler.LogError(ex.Message);
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", ex.Message);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", ex.Message);
                 throw;
             }
             catch (Exception ex)
             {
                 LoggingHandler.LogError(ex.Message);
-                await _batchLogErrorGateway.CreateAsync(batch.Id, "ERROR", ex.Message);
+                await _batchLogErrorGateway.CreateAsync(batch?.Id, "ERROR", ex.Message);
                 throw;
             }
         }


### PR DESCRIPTION
# What:
 - Fix NullReferenceException that happens whilst calling BatchLogError Gateway.

# Why:
- Whenever a legitimate error happens during the nightly process, if the `batch` remains, for some reason, set to `null`, the original error never gets reported to the batch log error & the process failure message gets obscured by this secondary null reference error.