### PR TITLE
Tweak dependency version to get the pipeline's deployment step working again. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@3.38.0
       - run:
           name: Install step function plugin          
           command: npm i serverless-step-functions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless@3.38.0
+          command: npm i -g serverless@^3
       - run:
           name: Install step function plugin          
           command: npm i serverless-step-functions


### PR DESCRIPTION
# What:
 - Tweak node to asked version of v18.
 - Tweak serverless to version of v3.

# Why:
 - Recent latest serverless package version no longer supports older node version.
 - The serverless v4 is still in beta, plus requires a paid license.

# Notes:
 - There's not 1 benefit that would make us need serverless v4 that we don't already have available on v3. So to avoid the account setup + licensing, limiting the sls version to v3 for the time being.
 - More on Licensing changes [[here](https://www.serverless.com/framework/docs/guides/upgrading-v4)].
 
 # Screenshots:
| ![image](https://github.com/LBHackney-IT/housing-finance-interim-api/assets/43747286/a98d4770-6ed4-44f7-925e-31786a1461c8) | ![image](https://github.com/LBHackney-IT/housing-finance-interim-api/assets/43747286/8c6540b5-0359-44c5-aa1d-e98dcaf53f7e) |
| --- | --- |
| No node v18 | v4 of sls |