### PR TITLE
POST Operating Balances by Rent Account endpoint (queue report)

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
@@ -220,6 +220,50 @@ namespace HousingFinanceInterimApi.Tests.V1.Factories
         }
         #endregion
 
+        #region Operating Balances by Rent Account
+        [Fact]
+        public void NullBatchReportOperatingBalancesByRentAccountRequestGetsMappedToNull()
+        {
+            // arrange
+            var batchReportOBRARequest = null as BatchReportOperatingBalancesByRentAccountRequest;
+
+            // act
+            var batchReportDomain = batchReportOBRARequest.ToDomain();
+
+            // assert
+            batchReportDomain.Should().BeNull();
+        }
+
+        [Fact]
+        public void BatchReportOperatingBalancesByRentAccountRequestGetsMappedToDomain()
+        {
+            // arrange
+            var batchReportOBRARequest = RandomGen.Create<BatchReportOperatingBalancesByRentAccountRequest>();
+
+            // act
+            var batchReportDomain = batchReportOBRARequest.ToDomain();
+
+            // assert
+            batchReportDomain.Should().NotBeNull();
+
+            batchReportDomain.Id.Should().Be(default);
+            batchReportDomain.ReportName.Should().Be(default);
+            batchReportDomain.RentGroup.Should().Be(batchReportOBRARequest.RentGroup);
+            batchReportDomain.Group.Should().Be(default);
+            batchReportDomain.TransactionType.Should().Be(default);
+            batchReportDomain.ReportStartDate.Should().Be(default);
+            batchReportDomain.ReportEndDate.Should().Be(default);
+            batchReportDomain.ReportDate.Should().Be(default);
+            batchReportDomain.ReportYear.Should().Be(batchReportOBRARequest.FinancialYear);
+            batchReportDomain.Link.Should().Be(default);
+            batchReportDomain.StartTime.Should().Be(default);
+            batchReportDomain.EndTime.Should().Be(default);
+            batchReportDomain.ReportStartWeekOrMonth.Should().Be(batchReportOBRARequest.StartWeekOrMonth);
+            batchReportDomain.ReportEndWeekOrMonth.Should().Be(batchReportOBRARequest.EndWeekOrMonth);
+            batchReportDomain.IsSuccess.Should().Be(default);
+        }
+        #endregion
+
         #region Itemised Transactions
         [Fact]
         public void BatchReportItemisedTransactionRequestGetsMappedToDomain()

--- a/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
@@ -262,6 +262,44 @@ namespace HousingFinanceInterimApi.Tests.V1.Factories
             batchReportDomain.ReportEndWeekOrMonth.Should().Be(batchReportOBRARequest.EndWeekOrMonth);
             batchReportDomain.IsSuccess.Should().Be(default);
         }
+
+        [Fact]
+        public void BatchReportOperatingBalancesByRentAccountGetsMappedToNullIfBatchReportDomainSourceIsNull()
+        {
+            // arrange
+            BatchReportDomain batchReportDomain = null;
+
+            // act
+            var resultOBRAResponse = batchReportDomain.ToReportOperatingBalancesByRentAccountResponse();
+
+            // assert
+            resultOBRAResponse.Should().BeNull();
+        }
+
+        [Fact]
+        public void BatchReportDomainGetsMappedToBatchReportOperatingBalancesByRentAccountResponse()
+        {
+            // arrange
+            var batchReportDomain = RandomGen.Create<BatchReportDomain>();
+
+            // act
+            var batchReportITResponse = batchReportDomain.ToReportOperatingBalancesByRentAccountResponse();
+
+            // assert
+            batchReportITResponse.Should().NotBeNull();
+
+            batchReportITResponse.Id.Should().Be(batchReportDomain.Id);
+            batchReportITResponse.RentGroup.Should().Be(batchReportDomain.RentGroup);
+            batchReportITResponse.FinancialYear.Should().Be(batchReportDomain.ReportYear);
+
+            batchReportITResponse.StartWeekOrMonth.Should().Be(batchReportDomain.ReportStartWeekOrMonth);
+            batchReportITResponse.EndWeekOrMonth.Should().Be(batchReportDomain.ReportEndWeekOrMonth);
+
+            batchReportITResponse.StartTime.Should().Be(batchReportDomain.StartTime);
+            batchReportITResponse.EndTime.Should().Be(batchReportDomain.EndTime);
+            batchReportITResponse.Link.Should().Be(batchReportDomain.Link);
+            batchReportITResponse.IsSuccess.Should().Be(batchReportDomain.IsSuccess);
+        }
         #endregion
 
         #region Itemised Transactions

--- a/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
@@ -36,6 +36,8 @@ namespace HousingFinanceInterimApi.Tests.V1.Factories
             batchReportInfrastructure.ReportStartDate.Should().Be(batchReportDomain.ReportStartDate);
             batchReportInfrastructure.ReportEndDate.Should().Be(batchReportDomain.ReportEndDate);
             batchReportInfrastructure.ReportDate.Should().Be(batchReportDomain.ReportDate);
+            batchReportInfrastructure.ReportStartWeekOrMonth.Should().Be(batchReportDomain.ReportStartWeekOrMonth);
+            batchReportInfrastructure.ReportEndWeekOrMonth.Should().Be(batchReportDomain.ReportEndWeekOrMonth);
             batchReportInfrastructure.ReportYear.Should().Be(batchReportDomain.ReportYear);
             batchReportInfrastructure.Link.Should().Be(batchReportDomain.Link);
             batchReportInfrastructure.StartTime.Should().Be(batchReportDomain.StartTime);

--- a/HousingFinanceInterimApi/V1/Boundary/Request/BatchReportOperatingBalancesByRentAccountRequest.cs
+++ b/HousingFinanceInterimApi/V1/Boundary/Request/BatchReportOperatingBalancesByRentAccountRequest.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace HousingFinanceInterimApi.V1.Boundary.Request
+{
+    public class BatchReportOperatingBalancesByRentAccountRequest
+    {
+        [Required]
+        [StringLength(3)]
+        public string RentGroup { get; set; }
+
+        [Required]
+        [Range(1900, 3000)]
+        public int FinancialYear { get; set; }
+
+        [Required]
+        [Range(1, 53)]
+        public int StartWeekOrMonth { get; set; }
+
+        [Required]
+        [Range(1, 53)]
+        public int EndWeekOrMonth { get; set; }
+    }
+}

--- a/HousingFinanceInterimApi/V1/Boundary/Response/BatchReportOperatingBalancesByRentAccountResponse.cs
+++ b/HousingFinanceInterimApi/V1/Boundary/Response/BatchReportOperatingBalancesByRentAccountResponse.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace HousingFinanceInterimApi.V1.Boundary.Response
+{
+    public class BatchReportOperatingBalancesByRentAccountResponse
+    {
+        public int Id { get; set; }
+        public string RentGroup { get; set; }
+        public int FinancialYear { get; set; }
+        public int StartWeekOrMonth { get; set; }
+        public int EndWeekOrMonth { get; set; }
+        public DateTimeOffset StartTime { get; set; }
+        public DateTimeOffset? EndTime { get; set; }
+        public string Link { get; set; }
+        public bool IsSuccess { get; set; }
+    }
+}

--- a/HousingFinanceInterimApi/V1/Controllers/ReportController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/ReportController.cs
@@ -23,6 +23,7 @@ namespace HousingFinanceInterimApi.V1.Controllers
 
         private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
         private const string ReportChargesLabel = "ReportCharges";
+        private const string ReportOperatingBalancesByRentAccount = "ReportOperatingBalancesByRentAccount";
         private const string ReportItemisedTransactionsLabel = "ReportItemisedTransactions";
         private const string ReportCashSuspenseLabel = "ReportCashSuspense";
         private const string ReportCashImportLabel = "ReportCashImport";
@@ -68,6 +69,33 @@ namespace HousingFinanceInterimApi.V1.Controllers
             return Ok(batchReportCharges.ToReportChargesResponse());
         }
 
+        # region Operating Balances by Rent Account
+        [ProducesResponseType(typeof(BatchReportOperatingBalancesByRentAccountResponse), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(BadRequestObjectResult), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [HttpPost]
+        [Route("operating-balances-by-rent-account")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
+        public async Task<IActionResult> CreateReportOperatingBalancesByRentAccount(
+            [FromBody] BatchReportOperatingBalancesByRentAccountRequest request)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var batchReport = request.ToDomain();
+            batchReport.ReportName = ReportOperatingBalancesByRentAccount;
+
+            var batchReportOperatingBalancesByRentAccount = await _batchReportGateway
+                .CreateAsync(batchReport)
+                .ConfigureAwait(false);
+
+            return Created(
+                    "Report request created",
+                    batchReportOperatingBalancesByRentAccount
+                        .ToReportOperatingBalancesByRentAccountResponse()
+                );
+        }
+        #endregion
         # region Itemised Transactions
         [ProducesResponseType(typeof(BatchReportItemisedTransactionResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(BadRequestObjectResult), StatusCodes.Status400BadRequest)]

--- a/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
+++ b/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
@@ -90,6 +90,25 @@ namespace HousingFinanceInterimApi.V1.Factories
                 ReportEndWeekOrMonth = batchReportRequest.EndWeekOrMonth
             };
         }
+
+        public static BatchReportOperatingBalancesByRentAccountResponse ToReportOperatingBalancesByRentAccountResponse(this BatchReportDomain batchReport)
+        {
+            if (batchReport == null)
+                return null;
+
+            return new BatchReportOperatingBalancesByRentAccountResponse
+            {
+                Id = batchReport.Id,
+                RentGroup = batchReport.RentGroup,
+                FinancialYear = batchReport.ReportYear.Value,
+                StartWeekOrMonth = batchReport.ReportStartWeekOrMonth.Value,
+                EndWeekOrMonth = batchReport.ReportEndWeekOrMonth.Value,
+                StartTime = batchReport.StartTime,
+                EndTime = batchReport.EndTime,
+                Link = batchReport.Link,
+                IsSuccess = batchReport.IsSuccess
+            };
+        }
         #endregion
         #region Itemised Transactions
         public static BatchReportDomain ToDomain(this BatchReportItemisedTransactionRequest batchReportRequest)

--- a/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
+++ b/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
@@ -217,6 +217,8 @@ namespace HousingFinanceInterimApi.V1.Factories
                 ReportEndDate = batchReport.ReportEndDate,
                 ReportYear = batchReport.ReportYear,
                 ReportDate = batchReport.ReportDate,
+                ReportStartWeekOrMonth = batchReport.ReportStartWeekOrMonth,
+                ReportEndWeekOrMonth = batchReport.ReportEndWeekOrMonth,
                 Link = batchReport.Link,
                 StartTime = batchReport.StartTime,
                 EndTime = batchReport.EndTime,

--- a/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
+++ b/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
@@ -76,6 +76,21 @@ namespace HousingFinanceInterimApi.V1.Factories
             return batchReportCharges?.Select(b => b.ToDomain()).ToList();
         }
 
+        #region Operating Balances by Rent Account
+        public static BatchReportDomain ToDomain(this BatchReportOperatingBalancesByRentAccountRequest batchReportRequest)
+        {
+            if (batchReportRequest == null)
+                return null;
+
+            return new BatchReportDomain
+            {
+                RentGroup = batchReportRequest.RentGroup,
+                ReportYear = batchReportRequest.FinancialYear,
+                ReportStartWeekOrMonth = batchReportRequest.StartWeekOrMonth,
+                ReportEndWeekOrMonth = batchReportRequest.EndWeekOrMonth
+            };
+        }
+        #endregion
         #region Itemised Transactions
         public static BatchReportDomain ToDomain(this BatchReportItemisedTransactionRequest batchReportRequest)
         {


### PR DESCRIPTION
# What:
 - The HTTP **POST** `/api/v1/report/operating-balances-by-rent-account` endpoint.

# Why:
 - This endpoint is used to add a queue 'event' item into the database for scheduling the generation of the "Operating Balances by Rent Account" CSV report file.

# Notes:
 - This portion of the application has quite a bit of tech debt. These changes happen to introduce a little extra. Why? The refactoring this application portion needs needs a little bit of thinking about it. As such, the avoidance of TD that could be done would simply create another case to consider once doing the refactoring, as such, the current shared pattern was used for the sake of consistency.
 - Changes seem to work fine when running the application locally.

# Extra Info: 
## Example Payload:
``` json
{
	"rentGroup": "LMW",
	"financialYear": 2022,
	"startWeekOrMonth": 1,
	"endWeekOrMonth": 5
}
```
## Extra notes on fields:
 1. RentGroup is expected as a **3 character string**. As all the RentGroups fit this description. RentGroups are static when it comes to business. Their codes haven't changed over many years, so we don't expect the higher length string any time soon.
 2.  Financial Years was set to a minimum of 1900s as that's the minimum date within the database, however, in reality the real minimum will be some time 2000s+. The max value was set to be 3000 just for the sake of limiting crazy high integer values.
 3. Start/End WeekOrMonth as the name suggests, either represents a Week or a Month depending on the RentGroup. The LMW and LSC RentGroups are Monthly, while the rest of them are Weekly. The restriction of 1 to 53 mainly focuses on Weeks as Month values are a subset of that. There are typically 52 weeks per year, but for instance, this leap year had 53 weeks, as such that's the highest value.