### PR TITLE
Increase 'Get Operating Balances by Rent Account' procedure timeout l…

### DIFF
--- a/HousingFinanceInterimApi/V1/Infrastructure/DatabaseContext.cs
+++ b/HousingFinanceInterimApi/V1/Infrastructure/DatabaseContext.cs
@@ -355,11 +355,14 @@ namespace HousingFinanceInterimApi.V1.Infrastructure
                 .ConfigureAwait(false);
 
         public async Task<IList<PRNTransactionEntity>> GetPRNTransactionsByRentGroupAsync(string rentGroup, int financialYear, int startWeekOrMonth, int endWeekOrMonth)
-            => await PRNTransaction
+        {
+            Database.SetCommandTimeout(timeout: 900); // set it equal to lambda timeout
+            return await PRNTransaction
                 .FromSqlInterpolated(
                     $"usp_GenerateOperatingBalanceAccounts @rent_group={rentGroup}, @post_year={financialYear}, @start_period={startWeekOrMonth}, @end_period={endWeekOrMonth}")
                 .ToListAsync()
                 .ConfigureAwait(false);
+        }
 
         public async Task RefreshTenancyAgreementTables(long batchLogId)
             => await PerformTransaction($"usp_RefreshTenancyAgreement {batchLogId}", 600).ConfigureAwait(false);


### PR DESCRIPTION
# What:
- Increase Timeout for the _(get)_ `Operating Balances by Rent Account` stored procedure query like on other S.P. calls.

# Why:
- The query is taking longer than the connection stays open.

# Notes:
 - Didn't notice this locally as I've configured my test setup with the timeout in mind, which I didn't commit :persevere:
 - This PR is an addon to #137 and #139 