### PR TITLE
GET 'Operating Balances by Rent Account' event items endpoint

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/Controllers/ReportControllerTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Controllers/ReportControllerTests.cs
@@ -526,7 +526,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Controllers
         }
 
         [Fact]
-        public async Task ListReportOperatingBalancesByRentAccountReturnsListOfBatchReportOperatingBalancesByRentAccountResponseItemsMatchingGWResponseWhenExecutionEndInSuccess()
+        public async Task OnSuccessTheListReportOperatingBalancesByRentAccountEPReturnsResponseItemsMatchingGWResponse()
         {
             // Arrange
             var batchReportOpBalsByRentAccGWResult = RandomGen.CreateMany<BatchReportDomain>();

--- a/HousingFinanceInterimApi.Tests/V1/Controllers/ReportControllerTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Controllers/ReportControllerTests.cs
@@ -502,6 +502,119 @@ namespace HousingFinanceInterimApi.Tests.V1.Controllers
             statusCodeResult.Should().NotBeNull();
             statusCodeResult.StatusCode.Should().Be(400);
         }
+
+        [Fact]
+        public async Task ListReportOperatingBalancesByRentAccountCallsBatchReportGWListMethodWithCorrectParameters()
+        {
+            // Arrange
+            var batchReportOpBalsByRentAccGWResult = new List<BatchReportDomain>();
+
+            _batchReportGatewayMock
+                .Setup(g => g.ListAsync(It.IsAny<string>()))
+                .ReturnsAsync(batchReportOpBalsByRentAccGWResult);
+
+            // Act
+            await _classUnderTest
+                .ListReportOperatingBalancesByRentAccount()
+                .ConfigureAwait(false);
+
+            // Assert
+            _batchReportGatewayMock.Verify(
+                g => g.ListAsync(It.Is<string>(reportName => reportName == "ReportOperatingBalancesByRentAccount")),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task ListReportOperatingBalancesByRentAccountReturnsListOfBatchReportOperatingBalancesByRentAccountResponseItemsMatchingGWResponseWhenExecutionEndInSuccess()
+        {
+            // Arrange
+            var batchReportOpBalsByRentAccGWResult = RandomGen.CreateMany<BatchReportDomain>();
+            var batchReportOpBalsByRentAccResponse = batchReportOpBalsByRentAccGWResult
+                .ToReportOperatingBalancesByRentAccountResponse();
+
+            _batchReportGatewayMock
+                .Setup(g => g.ListAsync(It.IsAny<string>()))
+                .ReturnsAsync(batchReportOpBalsByRentAccGWResult);
+
+            // Act
+            var response = await _classUnderTest
+                .ListReportOperatingBalancesByRentAccount()
+                .ConfigureAwait(false);
+
+            // Assert
+            var createdResult = response as OkObjectResult;
+            createdResult.Should().NotBeNull();
+            createdResult.StatusCode.Should().Be(200);
+
+            var responseObject = createdResult.Value as List<BatchReportOperatingBalancesByRentAccountResponse>;
+            responseObject.Should().HaveSameCount(batchReportOpBalsByRentAccGWResult);
+            responseObject.Should().BeEquivalentTo(batchReportOpBalsByRentAccResponse);
+        }
+
+        [Fact]
+        public async Task ListReportOperatingBalancesByRentAccountReturnsEmptyListResponseWhenGatewayFindsNoItems()
+        {
+            // Arrange
+            var batchReportOpBalsByRentAccGWResult = new List<BatchReportDomain>();
+
+            _batchReportGatewayMock
+                .Setup(g => g.ListAsync(It.IsAny<string>()))
+                .ReturnsAsync(batchReportOpBalsByRentAccGWResult);
+
+            // Act
+            var response = await _classUnderTest
+                .ListReportOperatingBalancesByRentAccount()
+                .ConfigureAwait(false);
+
+            // Assert
+            var createdResult = response as OkObjectResult;
+            createdResult.Should().NotBeNull();
+            createdResult.StatusCode.Should().Be(200);
+
+            var responseObject = createdResult.Value as List<BatchReportOperatingBalancesByRentAccountResponse>;
+            responseObject.Should().HaveCount(0);
+        }
+
+        [Fact]
+        public async Task ListReportOperatingBalancesByRentAccountReturnsA404NotFoundResponseWhenGatewayIsUnableToFindTheCollection()
+        {
+            // Arrange
+            IList<BatchReportDomain> batchReportOpBalsByRentAccGWResult = null;
+
+            _batchReportGatewayMock
+                .Setup(g => g.ListAsync(It.IsAny<string>()))
+                .ReturnsAsync(batchReportOpBalsByRentAccGWResult);
+
+            // Act
+            var response = await _classUnderTest
+                .ListReportOperatingBalancesByRentAccount()
+                .ConfigureAwait(false);
+
+            // Assert
+            var createdResult = response as NotFoundResult;
+            createdResult.Should().NotBeNull();
+            createdResult.StatusCode.Should().Be(404);
+        }
+
+        [Fact]
+        public async Task ListReportOperatingBalancesByRentAccountThrowsWhenAnExceptionIsRaisedDuringItsExecutionFlow()
+        {
+            // Arrange
+            var message = "Database credentials are not valid.";
+
+            _batchReportGatewayMock
+                .Setup(g => g.ListAsync(It.IsAny<string>()))
+                .ThrowsAsync(new ConnectionAbortedException(message));
+
+            // Act
+            Func<Task> endpointCall = async () => await _classUnderTest
+                .ListReportOperatingBalancesByRentAccount()
+                .ConfigureAwait(false);
+
+            // Assert
+            await endpointCall.Should().ThrowAsync<ConnectionAbortedException>().WithMessage(message);
+        }
         #endregion
 
         #region Itemised Transactions

--- a/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
@@ -346,7 +346,8 @@ namespace HousingFinanceInterimApi.Tests.V1.Factories
 
             // assert
             Predicate<BatchReportOperatingBalancesByRentAccountResponse> checkMappingNotBlank =
-                (BatchReportOperatingBalancesByRentAccountResponse responseItem) => {
+                (BatchReportOperatingBalancesByRentAccountResponse responseItem) =>
+                {
                     var domainItem = batchReportDomainCollection.FirstOrDefault(i => i.Id == responseItem.Id, defaultValue: null);
                     return domainItem is not null &&
                         domainItem.RentGroup == responseItem.RentGroup &&

--- a/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Factories/BatchReportFactoryTests.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using HousingFinanceInterimApi.Tests.V1.TestHelpers;
 using HousingFinanceInterimApi.V1.Boundary.Request;
+using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Domain;
 using HousingFinanceInterimApi.V1.Factories;
 using Xunit;
@@ -301,6 +305,57 @@ namespace HousingFinanceInterimApi.Tests.V1.Factories
             batchReportITResponse.EndTime.Should().Be(batchReportDomain.EndTime);
             batchReportITResponse.Link.Should().Be(batchReportDomain.Link);
             batchReportITResponse.IsSuccess.Should().Be(batchReportDomain.IsSuccess);
+        }
+
+        [Fact]
+        public void BatchReportDomainCollectionGetsMappedToNullWhenTheItIsNull()
+        {
+            // arrange
+            var batchReportDomainCollection = null as List<BatchReportDomain>;
+
+            // act
+            var mappedResult = batchReportDomainCollection.ToReportOperatingBalancesByRentAccountResponse();
+
+            // assert
+            mappedResult.Should().BeNull();
+        }
+
+        [Fact]
+        public void EmptyBatchReportDomainCollectionGetsMappedToEmptyBatchReportOperatingBalancesByRentAccountResponseCollection()
+        {
+            // arrange
+            var batchReportDomainCollection = RandomGen.CreateMany<BatchReportDomain>(quantity: 0);
+
+            // act
+            var mappedResult = batchReportDomainCollection.ToReportOperatingBalancesByRentAccountResponse();
+
+            // assert
+            mappedResult.Should().NotBeNull();
+            mappedResult.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void BatchReportDomainCollectionGetsMappedToBatchReportOperatingBalancesByRentAccountResponseCollection()
+        {
+            // arrange
+            var expectedItemCount = 4;
+            var batchReportDomainCollection = RandomGen.CreateMany<BatchReportDomain>(quantity: expectedItemCount);
+
+            // act
+            var mappedResult = batchReportDomainCollection.ToReportOperatingBalancesByRentAccountResponse();
+
+            // assert
+            Predicate<BatchReportOperatingBalancesByRentAccountResponse> checkMappingNotBlank =
+                (BatchReportOperatingBalancesByRentAccountResponse responseItem) => {
+                    var domainItem = batchReportDomainCollection.FirstOrDefault(i => i.Id == responseItem.Id, defaultValue: null);
+                    return domainItem is not null &&
+                        domainItem.RentGroup == responseItem.RentGroup &&
+                        domainItem.Link == responseItem.Link;
+                };
+
+            mappedResult.Should().NotBeNull();
+            mappedResult.Should().HaveCount(expectedItemCount);
+            mappedResult.Should().OnlyContain(mi => checkMappingNotBlank(mi));
         }
         #endregion
 

--- a/HousingFinanceInterimApi/V1/Controllers/ReportController.cs
+++ b/HousingFinanceInterimApi/V1/Controllers/ReportController.cs
@@ -95,6 +95,30 @@ namespace HousingFinanceInterimApi.V1.Controllers
                         .ToReportOperatingBalancesByRentAccountResponse()
                 );
         }
+
+        [ProducesResponseType(
+            typeof(List<BatchReportOperatingBalancesByRentAccountResponse>),
+            StatusCodes.Status200OK
+        )]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [HttpGet]
+        [Route("operating-balances-by-rent-account")]
+        [AuthorizeEndpointByGroups("HOUSING_FINANCE_ALLOWED_GROUPS")]
+        public async Task<IActionResult> ListReportOperatingBalancesByRentAccount()
+        {
+            var batchReportOperatingBalancesByRentAccount = await _batchReportGateway
+                .ListAsync(ReportOperatingBalancesByRentAccount)
+                .ConfigureAwait(false);
+
+            if (batchReportOperatingBalancesByRentAccount is null)
+                return NotFound();
+
+            return Ok(
+                batchReportOperatingBalancesByRentAccount
+                    .ToReportOperatingBalancesByRentAccountResponse()
+            );
+        }
         #endregion
         # region Itemised Transactions
         [ProducesResponseType(typeof(BatchReportItemisedTransactionResponse), StatusCodes.Status201Created)]

--- a/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
+++ b/HousingFinanceInterimApi/V1/Factories/BatchReport.cs
@@ -109,6 +109,12 @@ namespace HousingFinanceInterimApi.V1.Factories
                 IsSuccess = batchReport.IsSuccess
             };
         }
+
+        public static List<BatchReportOperatingBalancesByRentAccountResponse> ToReportOperatingBalancesByRentAccountResponse(
+            this ICollection<BatchReportDomain> batchReports)
+        {
+            return batchReports?.Select(b => b.ToReportOperatingBalancesByRentAccountResponse()).ToList();
+        }
         #endregion
         #region Itemised Transactions
         public static BatchReportDomain ToDomain(this BatchReportItemisedTransactionRequest batchReportRequest)


### PR DESCRIPTION
# What:
 - The HTTP **GET** `/api/v1/report/operating-balances-by-rent-account` endpoint.

# Why:
 - This endpoint is used to to the fetch all historically placed queue 'event' items for the "Operating Balances by Rent Account" dashboard.

# Notes:
 - Same as for PR #141 

# Example Response:
``` json
[
	{
		"id": 231,
		"rentGroup": "LMW",
		"financialYear": 2023,
		"startWeekOrMonth": 2,
		"endWeekOrMonth": 5,
		"startTime": "2024-05-24T13:33:57.3233333+00:00",
		"endTime": "2024-05-24T15:13:05.9493775+01:00",
		"link": "Output folder not found",
		"isSuccess": false
	},
	{
		"id": 232,
		"rentGroup": "HRA",
		"financialYear": 2025,
		"startWeekOrMonth": 1,
		"endWeekOrMonth": 53,
		"startTime": "2024-05-24T14:17:01.1366667+00:00",
		"endTime": "2024-05-24T16:25:48.1177889+01:00",
		"link": "https://drive.google.com/file/d/1li8---aE5ILx235W03qLcgfbrTNW3BoU",
		"isSuccess": true
	}
]
```