### PR TITLE
Speed up GenerateReportUseCase Tests

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -1701,8 +1701,6 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
             // assert
-            Assert.True(stepResponse.Continue);
-
             _mockGoogleClientService.Verify(
                 g => g.GetFileByNameInDriveAsync(
                     It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
@@ -1781,9 +1779,10 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
             // assert
-            var secondsSpentInWaitForTheFile = (lastAttempt - firstAttempt).Value.TotalSeconds + (_retryInterval / 1000);
+            Assert.True(firstAttempt.HasValue);
+            var secondsSpentInWaitForTheFile = (lastAttempt - firstAttempt).Value.TotalSeconds + (_retryInterval / 1000.0);
 
-            Math.Round(secondsSpentInWaitForTheFile, 2).Should().Be((double) (_waitDuration - _retryInterval) / 1000);
+            Math.Round(secondsSpentInWaitForTheFile, 2).Should().Be( _waitDuration / 1000.0);
 
             _mockGoogleClientService.Verify(
                 g => g.GetFileByNameInDriveAsync(

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -15,3099 +15,3099 @@ using HousingFinanceInterimApi.V1.Helpers;
 using FluentAssertions.Common;
 using System.Text;
 
-namespace HousingFinanceInterimApi.Tests.V1.UseCase
+namespace HousingFinanceInterimApi.Tests.V1.UseCase;
+
+public class GenerateReportUseCaseTests
 {
-    public class GenerateReportUseCaseTests
+    private readonly Mock<IBatchReportGateway> _mockBatchReportGateway;
+    private readonly Mock<IReportGateway> _mockReportGateway;
+    private readonly Mock<ITransactionGateway> _mockTransactionGateway;
+    private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
+    private readonly Mock<IGoogleClientService> _mockGoogleClientService;
+    private readonly int _waitDuration = 30;
+    private readonly IGenerateReportUseCase _classUnderTest;
+
+    public GenerateReportUseCaseTests()
     {
-        private readonly Mock<IBatchReportGateway> _mockBatchReportGateway;
-        private readonly Mock<IReportGateway> _mockReportGateway;
-        private readonly Mock<ITransactionGateway> _mockTransactionGateway;
-        private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
-        private readonly Mock<IGoogleClientService> _mockGoogleClientService;
-        private readonly int _waitDuration = 30;
-        private readonly IGenerateReportUseCase _classUnderTest;
+        _mockBatchReportGateway = new Mock<IBatchReportGateway>();
+        _mockReportGateway = new Mock<IReportGateway>();
+        _mockTransactionGateway = new();
+        _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
+        _mockGoogleClientService = new Mock<IGoogleClientService>();
 
-        public GenerateReportUseCaseTests()
-        {
-            _mockBatchReportGateway = new Mock<IBatchReportGateway>();
-            _mockReportGateway = new Mock<IReportGateway>();
-            _mockTransactionGateway = new();
-            _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
-            _mockGoogleClientService = new Mock<IGoogleClientService>();
+        Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
 
-            Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
-
-            _classUnderTest = new GenerateReportUseCase(
-                    _mockBatchReportGateway.Object,
-                    _mockReportGateway.Object,
-                    _mockTransactionGateway.Object,
-                    _mockGoogleFileSettingGateway.Object,
-                    _mockGoogleClientService.Object
-                );
-        }
-
-        #region Shared
-        [Fact]
-        public async Task GenerateReportUCChecksWhetherAnyUnprocessedReportRequestsExist()
-        {
-            // arrange
-            var unprocessedReports = new List<BatchReportDomain>();
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(g => g.ListPendingAsync(), Times.Once);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenThereAreNoReportRequestsToProcess()
-        {
-            // arrange
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-            var unprocessedReports = new List<BatchReportDomain>();
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeFalse();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenTheRequestedReportNameFoundIsUnknown()
-        {
-            // arrange
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-            var unknownTypeUnprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, "Pepsi > CocaCola")
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unknownTypeUnprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCStartsGeneratingTheEarliestRequestedReportInTheQueue()
-        {
-            // arrange
-            var expectedearliestReportLabel = "ReportItemisedTransactions";
-
-            var earliestRequestedUnprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, expectedearliestReportLabel)
-                .With(r => r.StartTime, DateTime.Now.AddMinutes(-20))
-                .CreateCustom();
-
-            var lastRequestedUnprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, "ReportCashSuspense")
-                .With(r => r.StartTime, DateTime.Now)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { lastRequestedUnprocessedReport, earliestRequestedUnprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var accountBalanceFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, expectedearliestReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == expectedearliestReportLabel)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCThrowsAnExceptionWheneverOneIsRaisedWithinIt()
-        {
-            // arrange
-            var message = "The premise of the argument is incorrect.";
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ThrowsAsync(new ArgumentException(message));
-
-            // act
-            Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message);
-        }
-        #endregion
-
-        #region Account Balance
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnAccountBalance()
-        {
-            // arrange
-            var requestedReportLabel = "ReportAccountBalanceByDate";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var accountBalanceFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenAccountBalanceFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportAccountBalanceByDate";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
+        _classUnderTest = new GenerateReportUseCase(
+                _mockBatchReportGateway.Object,
+                _mockReportGateway.Object,
+                _mockTransactionGateway.Object,
+                _mockGoogleFileSettingGateway.Object,
+                _mockGoogleClientService.Object
             );
+    }
 
-            _mockReportGateway.Verify(
-                g => g.GetReportAccountBalanceAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<string>()
+    #region Shared
+    [Fact]
+    public async Task GenerateReportUCChecksWhetherAnyUnprocessedReportRequestsExist()
+    {
+        // arrange
+        var unprocessedReports = new List<BatchReportDomain>();
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(g => g.ListPendingAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenThereAreNoReportRequestsToProcess()
+    {
+        // arrange
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+        var unprocessedReports = new List<BatchReportDomain>();
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeFalse();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenTheRequestedReportNameFoundIsUnknown()
+    {
+        // arrange
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+        var unknownTypeUnprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, "Pepsi > CocaCola")
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unknownTypeUnprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCStartsGeneratingTheEarliestRequestedReportInTheQueue()
+    {
+        // arrange
+        var expectedearliestReportLabel = "ReportItemisedTransactions";
+
+        var earliestRequestedUnprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, expectedearliestReportLabel)
+            .With(r => r.StartTime, DateTime.Now.AddMinutes(-20))
+            .CreateCustom();
+
+        var lastRequestedUnprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, "ReportCashSuspense")
+            .With(r => r.StartTime, DateTime.Now)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { lastRequestedUnprocessedReport, earliestRequestedUnprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var accountBalanceFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, expectedearliestReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == expectedearliestReportLabel)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCThrowsAnExceptionWheneverOneIsRaisedWithinIt()
+    {
+        // arrange
+        var message = "The premise of the argument is incorrect.";
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ThrowsAsync(new ArgumentException(message));
+
+        // act
+        Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message);
+    }
+    #endregion
+
+    #region Account Balance
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnAccountBalance()
+    {
+        // arrange
+        var requestedReportLabel = "ReportAccountBalanceByDate";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var accountBalanceFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenAccountBalanceFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportAccountBalanceByDate";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetReportAccountBalanceAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithDateTimeAndRentGroupFromTheReportRequestAlsoTheCreatedFileNameIsHasTrimmedRentGroup()
+    {
+        // arrange
+        var requestedRentGroup = "HRA";
+        var untrimmedRentGroup = $"  {requestedRentGroup} ";
+        var requestedReportLabel = "ReportAccountBalanceByDate";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, untrimmedRentGroup)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var accountBalanceFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetReportAccountBalanceAsync(
+                It.Is<DateTime>(d => d.Equals(unprocessedReport.ReportDate.Value)),
+                It.Is<string>(r => r == untrimmedRentGroup) // Odd, but that's the current behaviour.
+            ),
+            Times.Once
+        );
+
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.Is<string>(fn =>
+                    !fn.Contains(untrimmedRentGroup) &&
+                    fn.Contains(requestedRentGroup)
                 ),
-                Times.Never
-            );
-        }
+                It.IsAny<string>()
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithDateTimeAndRentGroupFromTheReportRequestAlsoTheCreatedFileNameIsHasTrimmedRentGroup()
-        {
-            // arrange
-            var requestedRentGroup = "HRA";
-            var untrimmedRentGroup = $"  {requestedRentGroup} ";
-            var requestedReportLabel = "ReportAccountBalanceByDate";
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithRentGroupValueSetAsNullButTheUploadedFileNameContainsTheValueALLWhenRentGroupIsNotProvided()
+    {
+        // arrange
+        var requestedReportLabel = "ReportAccountBalanceByDate";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, untrimmedRentGroup)
-                .CreateCustom();
+        string requestedRentGroup = null;
+        var allRentGroups = "ALL";
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, requestedRentGroup)
+            .CreateCustom();
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            var accountBalanceFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+        var accountBalanceFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetReportAccountBalanceAsync(
-                    It.Is<DateTime>(d => d.Equals(unprocessedReport.ReportDate.Value)),
-                    It.Is<string>(r => r == untrimmedRentGroup) // Odd, but that's the current behaviour.
-                ),
-                Times.Once
-            );
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.Is<string>(fn =>
-                        !fn.Contains(untrimmedRentGroup) &&
-                        fn.Contains(requestedRentGroup)
-                    ),
-                    It.IsAny<string>()
-                ),
-                Times.Once
-            );
-        }
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetReportAccountBalanceAsync(
+                It.IsAny<DateTime>(),
+                It.Is<string>(r => r == requestedRentGroup)
+            ),
+            Times.Once
+        );
 
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithRentGroupValueSetAsNullButTheUploadedFileNameContainsTheValueALLWhenRentGroupIsNotProvided()
-        {
-            // arrange
-            var requestedReportLabel = "ReportAccountBalanceByDate";
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.Is<string>(fn => fn.Contains(allRentGroups)),
+                It.IsAny<string>()
+            ),
+            Times.Once
+        );
+    }
 
-            string requestedRentGroup = null;
-            var allRentGroups = "ALL";
+    [Fact]
+    public async Task GenerateReportUCUploadsTheAccountBalanceDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+    {
+        // arrange
+        var requestedReportLabel = "ReportAccountBalanceByDate";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, requestedRentGroup)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var accountBalanceFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var accountBalanceFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetReportAccountBalanceAsync(
-                    It.IsAny<DateTime>(),
-                    It.Is<string>(r => r == requestedRentGroup)
-                ),
-                Times.Once
-            );
-
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.Is<string>(fn => fn.Contains(allRentGroups)),
-                    It.IsAny<string>()
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCUploadsTheAccountBalanceDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-        {
-            // arrange
-            var requestedReportLabel = "ReportAccountBalanceByDate";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var accountBalanceFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>() {
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3", "header 4" },
                 new string [] { "0008425", "HRA", "520.36", "2020-08-08" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetReportAccountBalanceAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetReportAccountBalanceAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn => fn.Contains("Account_Balance")),
-                    It.Is<string>(id => id == accountBalanceFolder.GoogleIdentifier)
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn => fn.Contains("Account_Balance")),
+                It.Is<string>(id => id == accountBalanceFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedAccountBalanceCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportAccountBalanceByDate";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var accountBalanceFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetReportAccountBalanceAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == accountBalanceFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Account_Balance") &&
+                    fn.Contains(unprocessedReport.RentGroup) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+    #endregion
+
+    #region Charges
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsCharges()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenChargesFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAndRentGroupAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetChargesByGroupTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAsync(
+                It.IsAny<int>()
+            ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetChargesByYearAndRentGroupWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheRentGroupIsNonEmpty()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAndRentGroupAsync(
+                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                It.Is<string>(r => r == unprocessedReport.RentGroup)
+            ),
+            Times.Once
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetChargesByGroupTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAsync(
+                It.IsAny<int>()
+            ),
+            Times.Never
+        );
+
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.Is<string>(fn =>
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.RentGroup) &&
+                    !fn.Contains(unprocessedReport.Group)
                 ),
-                Times.Once
-            );
-        }
+                It.IsAny<string>()
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedAccountBalanceCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportAccountBalanceByDate";
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetChargesByGroupTypeWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheGroupIsNonEmptyButTheRentGroupIsEmpty()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, null as string)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var accountBalanceFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockReportGateway
-                .Setup(g => g.GetReportAccountBalanceAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAndRentGroupAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
+        _mockReportGateway.Verify(
+            g => g.GetChargesByGroupTypeAsync(
+                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                It.Is<string>(r => r == unprocessedReport.Group)
+            ),
+            Times.Once
+        );
 
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAsync(
+                It.IsAny<int>()
+            ),
+            Times.Never
+        );
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == accountBalanceFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Account_Balance") &&
-                        fn.Contains(unprocessedReport.RentGroup) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.Is<string>(fn =>
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Group)
                 ),
-                Times.Once
-            );
+                It.IsAny<string>()
+            ),
+            Times.Once
+        );
+    }
 
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetChargesByYearWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenBothTheGroupAndTheRentGroupAreEmpty()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
 
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-        #endregion
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, null as string)
+            .With(r => r.Group, null as string)
+            .CreateCustom();
 
-        #region Charges
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsCharges()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAndRentGroupAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        _mockReportGateway.Verify(
+            g => g.GetChargesByGroupTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
 
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
+        _mockReportGateway.Verify(
+            g => g.GetChargesByYearAsync(
+                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value))
+            ),
+            Times.Once
+        );
 
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenChargesFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.Is<string>(fn =>
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString())
                 ),
-                Times.Once
-            );
+                It.IsAny<string>()
+            ),
+            Times.Once
+        );
+    }
 
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAndRentGroupAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
+    [Fact]
+    public async Task GenerateReportUCUploadsTheChargesByYearAndRentGroupDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
 
-            _mockReportGateway.Verify(
-                g => g.GetChargesByGroupTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAsync(
-                    It.IsAny<int>()
-                ),
-                Times.Never
-            );
-        }
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetChargesByYearAndRentGroupWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheRentGroupIsNonEmpty()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAndRentGroupAsync(
-                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                    It.Is<string>(r => r == unprocessedReport.RentGroup)
-                ),
-                Times.Once
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetChargesByGroupTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAsync(
-                    It.IsAny<int>()
-                ),
-                Times.Never
-            );
-
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.Is<string>(fn =>
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.RentGroup) &&
-                        !fn.Contains(unprocessedReport.Group)
-                    ),
-                    It.IsAny<string>()
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetChargesByGroupTypeWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheGroupIsNonEmptyButTheRentGroupIsEmpty()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, null as string)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAndRentGroupAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetChargesByGroupTypeAsync(
-                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                    It.Is<string>(r => r == unprocessedReport.Group)
-                ),
-                Times.Once
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAsync(
-                    It.IsAny<int>()
-                ),
-                Times.Never
-            );
-
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.Is<string>(fn =>
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Group)
-                    ),
-                    It.IsAny<string>()
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetChargesByYearWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenBothTheGroupAndTheRentGroupAreEmpty()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, null as string)
-                .With(r => r.Group, null as string)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAndRentGroupAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetChargesByGroupTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetChargesByYearAsync(
-                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value))
-                ),
-                Times.Once
-            );
-
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.Is<string>(fn =>
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString())
-                    ),
-                    It.IsAny<string>()
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCUploadsTheChargesByYearAndRentGroupDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>() {
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3", "header 4" },
                 new string [] { "0001234", "TRA", "130.36", "2025-01-06" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetChargesByYearAndRentGroupAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetChargesByYearAndRentGroupAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn => fn.Contains("Charges")),
-                    It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-                ),
-                Times.Once
-            );
-        }
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn => fn.Contains("Charges")),
+                It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCUploadsTheChargesByGroupTypeDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
+    [Fact]
+    public async Task GenerateReportUCUploadsTheChargesByGroupTypeDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, null as string)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, null as string)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>() {
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3", "header 4" },
                 new string [] { "0022455", "LSC", "7.88", "2023-04-22" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetChargesByGroupTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetChargesByGroupTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn => fn.Contains("Charges")),
-                    It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-                ),
-                Times.Once
-            );
-        }
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn => fn.Contains("Charges")),
+                It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCUploadsTheChargesByYearDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
+    [Fact]
+    public async Task GenerateReportUCUploadsTheChargesByYearDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, null as string)
-                .With(r => r.Group, null as string)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, null as string)
+            .With(r => r.Group, null as string)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>() {
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3", "header 4" },
                 new string [] { "0004567", "LMW", "70.11", "2015-02-14" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetChargesByYearAsync(
-                    It.IsAny<int>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn => fn.Contains("Charges")),
-                    It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedChargesByYearAndRentGroupCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetChargesByYearAndRentGroupAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Charges") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.RentGroup.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedChargesByGroupTypeCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, null as string)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetChargesByGroupTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Charges") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Group.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedChargesByYearCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCharges";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .With(r => r.RentGroup, null as string)
-                .With(r => r.Group, null as string)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var chargesFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetChargesByYearAsync(
-                    It.IsAny<int>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            var expectedNextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Charges") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(expectedNextStepTime, 1500);
-        }
-        #endregion
-
-        #region Itemised Transactions
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnItemisedTransactions()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenItemisedTransactionFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetItemisedTransactionsByYearAndTransactionTypeWithApproapriateParametersFromTheReportRequest()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.Is<int>(y => y == unprocessedReport.ReportYear.Value),
-                    It.Is<string>(t => t == unprocessedReport.TransactionType)
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCUploadsTheItemisedTransactionsDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>() {
+        _mockReportGateway
+            .Setup(g => g.GetChargesByYearAsync(
+                It.IsAny<int>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn => fn.Contains("Charges")),
+                It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedChargesByYearAndRentGroupCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetChargesByYearAndRentGroupAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Charges") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.RentGroup.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedChargesByGroupTypeCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, null as string)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetChargesByGroupTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Charges") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Group.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedChargesByYearCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCharges";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .With(r => r.RentGroup, null as string)
+            .With(r => r.Group, null as string)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var chargesFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetChargesByYearAsync(
+                It.IsAny<int>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        var expectedNextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Charges") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(expectedNextStepTime, 1500);
+    }
+    #endregion
+
+    #region Itemised Transactions
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnItemisedTransactions()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenItemisedTransactionFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetItemisedTransactionsByYearAndTransactionTypeWithApproapriateParametersFromTheReportRequest()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.Is<int>(y => y == unprocessedReport.ReportYear.Value),
+                It.Is<string>(t => t == unprocessedReport.TransactionType)
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCUploadsTheItemisedTransactionsDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3" },
                 new string [] { "00088255", "LMW", "251.23" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn =>
-                        fn.Contains("Itemised_Transactions") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.TransactionType) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                    ),
-                    It.Is<string>(id => id == itemisedTransactionsFolder.GoogleIdentifier)
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn =>
+                    fn.Contains("Itemised_Transactions") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.TransactionType) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
                 ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedItemisedTransactionsCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Itemised_Transactions") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.TransactionType) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
-
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedItemisedTransactionsFileIsNotFoundBeforeTheCutoffCheckingTime()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            GD.File uploadedCSVFile = null;
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
-
-            // act
-            Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            await generateAReportCall.Should().NotThrowAsync();
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Uploaded report file not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.IsAny<string>(),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Never
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int expectedNumberOfFileRetrievalAttempts = 30; //RandomGen.WholeNumber(1, 30);
-            int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
-            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
-            GD.File fileReturnedFromGDrive = null;
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .Callback(() => fileReturnedFromGDrive = DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFile)
-                .ReturnsAsync(fileReturnedFromGDrive);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Itemised_Transactions") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.TransactionType) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.Exactly(expectedNumberOfFileRetrievalAttempts)
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
-        {
-            // arrange
-            var requestedReportLabel = "ReportItemisedTransactions";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var itemisedTransactionsFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int cutOffForNumberOfAttempts = 30;
-            DateTime? firstAttempt = null;
-            DateTime lastAttempt = DateTime.MinValue;
-            GD.File fileReturnedFromGDrive = null;
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .Callback(() =>
-                {
-                    firstAttempt ??= DateTime.Now;
-                    lastAttempt = DateTime.Now;
-                })
-                .ReturnsAsync(fileReturnedFromGDrive);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
-
-            secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
-
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Itemised_Transactions") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.TransactionType) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.Exactly(cutOffForNumberOfAttempts)
-            );
-        }
-        #endregion
-
-        #region Cash Suspense
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashSuspense()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashSuspense";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var cashSuspenseFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashSuspenseFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashSuspense";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
-
-            _mockReportGateway.Verify(
-                g => g.GetCashSuspenseAccountByYearAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ),
-                Times.Never
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetCashSuspenseAccountByYearWithApproapriateParametersFromTheReportRequest()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashSuspense";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var cashSuspenseFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetCashSuspenseAccountByYearAsync(
-                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                    It.Is<string>(r => r == unprocessedReport.Group)
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCUploadsTheCashSuspenseDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashSuspense";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var cashSuspenseFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>() {
+                It.Is<string>(id => id == itemisedTransactionsFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedItemisedTransactionsCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Itemised_Transactions") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.TransactionType) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedItemisedTransactionsFileIsNotFoundBeforeTheCutoffCheckingTime()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        GD.File uploadedCSVFile = null;
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        await generateAReportCall.Should().NotThrowAsync();
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Uploaded report file not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.IsAny<string>(),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+        int expectedNumberOfFileRetrievalAttempts = 30; //RandomGen.WholeNumber(1, 30);
+        int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
+        var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
+        GD.File fileReturnedFromGDrive = null;
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .Callback(() => fileReturnedFromGDrive = DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFile)
+            .ReturnsAsync(fileReturnedFromGDrive);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Itemised_Transactions") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.TransactionType) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.Exactly(expectedNumberOfFileRetrievalAttempts)
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
+    {
+        // arrange
+        var requestedReportLabel = "ReportItemisedTransactions";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var itemisedTransactionsFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+        int cutOffForNumberOfAttempts = 30;
+        DateTime? firstAttempt = null;
+        DateTime lastAttempt = DateTime.MinValue;
+        GD.File fileReturnedFromGDrive = null;
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .Callback(() =>
+            {
+                firstAttempt ??= DateTime.Now;
+                lastAttempt = DateTime.Now;
+            })
+            .ReturnsAsync(fileReturnedFromGDrive);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+
+        secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Itemised_Transactions") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.TransactionType) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.Exactly(cutOffForNumberOfAttempts)
+        );
+    }
+    #endregion
+
+    #region Cash Suspense
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashSuspense()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashSuspense";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var cashSuspenseFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashSuspenseFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashSuspense";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockReportGateway.Verify(
+            g => g.GetCashSuspenseAccountByYearAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetCashSuspenseAccountByYearWithApproapriateParametersFromTheReportRequest()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashSuspense";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var cashSuspenseFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetCashSuspenseAccountByYearAsync(
+                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                It.Is<string>(r => r == unprocessedReport.Group)
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCUploadsTheCashSuspenseDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashSuspense";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var cashSuspenseFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3" },
                 new string [] { "0000112", "TRA", "0.01" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetCashSuspenseAccountByYearAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetCashSuspenseAccountByYearAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn =>
-                        fn.Contains("Cash_Suspense") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Group) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                    ),
-                    It.Is<string>(id => id == cashSuspenseFolder.GoogleIdentifier)
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn =>
+                    fn.Contains("Cash_Suspense") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Group) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
                 ),
-                Times.Once
-            );
-        }
+                It.Is<string>(id => id == cashSuspenseFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedCashSuspenseCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashSuspense";
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedCashSuspenseCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashSuspense";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var cashSuspenseFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var cashSuspenseFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>();
+        var spreadSheetData = new List<string[]>();
 
-            _mockReportGateway
-                .Setup(g => g.GetCashSuspenseAccountByYearAsync(
-                    It.IsAny<int>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetCashSuspenseAccountByYearAsync(
+                It.IsAny<int>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
 
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
 
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == cashSuspenseFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Cash_Suspense") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Group) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == cashSuspenseFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Cash_Suspense") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Group) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
 
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
 
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
 
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-        #endregion
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+    #endregion
 
-        #region Cash Import
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashImport()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashImport";
+    #region Cash Import
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashImport()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashImport";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var cashImportFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var cashImportFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
 
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashImportFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashImport";
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashImportFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashImport";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
 
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
 
-            _mockReportGateway.Verify(
-                g => g.GetCashImportByDateAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<DateTime>()
-                ),
-                Times.Never
-            );
-        }
+        _mockReportGateway.Verify(
+            g => g.GetCashImportByDateAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>()
+            ),
+            Times.Never
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetCashImportByDateWithApproapriateParametersFromTheReportRequest()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashImport";
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetCashImportByDateWithApproapriateParametersFromTheReportRequest()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashImport";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var cashImportFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var cashImportFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetCashImportByDateAsync(
-                    It.Is<DateTime>(s => s.Equals(unprocessedReport.ReportStartDate.Value)),
-                    It.Is<DateTime>(e => e.Equals(unprocessedReport.ReportEndDate.Value))
-                ),
-                Times.Once
-            );
-        }
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetCashImportByDateAsync(
+                It.Is<DateTime>(s => s.Equals(unprocessedReport.ReportStartDate.Value)),
+                It.Is<DateTime>(e => e.Equals(unprocessedReport.ReportEndDate.Value))
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCUploadsTheCashImportDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashImport";
+    [Fact]
+    public async Task GenerateReportUCUploadsTheCashImportDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashImport";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var cashImportFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var cashImportFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>() {
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3" },
                 new string [] { "0000223", "LSC", "3.01" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetCashImportByDateAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<DateTime>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetCashImportByDateAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn =>
-                        fn.Contains("Cash_Import") &&
-                        fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
-                        fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                    ),
-                    It.Is<string>(id => id == cashImportFolder.GoogleIdentifier)
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn =>
+                    fn.Contains("Cash_Import") &&
+                    fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
+                    fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
                 ),
-                Times.Once
-            );
-        }
+                It.Is<string>(id => id == cashImportFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedCashImportCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportCashImport";
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedCashImportCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportCashImport";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var cashImportFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var cashImportFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>();
+        var spreadSheetData = new List<string[]>();
 
-            _mockReportGateway
-                .Setup(g => g.GetCashImportByDateAsync(
-                    It.IsAny<DateTime>(),
-                    It.IsAny<DateTime>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetCashImportByDateAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
 
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
 
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == cashImportFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Cash_Import") &&
-                        fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
-                        fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == cashImportFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Cash_Import") &&
+                    fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
+                    fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
 
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
 
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
 
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-        #endregion
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+    #endregion
 
-        #region Housing Benefit Academy
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAHousingBenefitAcademy()
-        {
-            // arrange
-            var requestedReportLabel = "ReportHousingBenefitAcademy";
+    #region Housing Benefit Academy
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAHousingBenefitAcademy()
+    {
+        // arrange
+        var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var housingBenefitAcademyFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var housingBenefitAcademyFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
 
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenHousingBenefitAcademyFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportHousingBenefitAcademy";
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenHousingBenefitAcademyFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
 
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
 
-            _mockReportGateway.Verify(
-                g => g.GetHousingBenefitAcademyByYearAsync(
-                    It.IsAny<int>()
-                ),
-                Times.Never
-            );
-        }
+        _mockReportGateway.Verify(
+            g => g.GetHousingBenefitAcademyByYearAsync(
+                It.IsAny<int>()
+            ),
+            Times.Never
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCCallsTheReportGWGetHousingBenefitAcademyByYearWithApproapriateParametersFromTheReportRequest()
-        {
-            // arrange
-            var requestedReportLabel = "ReportHousingBenefitAcademy";
+    [Fact]
+    public async Task GenerateReportUCCallsTheReportGWGetHousingBenefitAcademyByYearWithApproapriateParametersFromTheReportRequest()
+    {
+        // arrange
+        var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var housingBenefitAcademyFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var housingBenefitAcademyFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
 
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockReportGateway.Verify(
-                g => g.GetHousingBenefitAcademyByYearAsync(
-                    It.Is<int>(s => s.Equals(unprocessedReport.ReportYear.Value))
-                ),
-                Times.Once
-            );
-        }
+        // assert
+        _mockReportGateway.Verify(
+            g => g.GetHousingBenefitAcademyByYearAsync(
+                It.Is<int>(s => s.Equals(unprocessedReport.ReportYear.Value))
+            ),
+            Times.Once
+        );
+    }
 
-        [Fact]
-        public async Task GenerateReportUCUploadsTheHousingBenefitAcademyDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-        {
-            // arrange
-            var requestedReportLabel = "ReportHousingBenefitAcademy";
+    [Fact]
+    public async Task GenerateReportUCUploadsTheHousingBenefitAcademyDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+    {
+        // arrange
+        var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
 
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-            var housingBenefitAcademyFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
+        var housingBenefitAcademyFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
 
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
 
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-            var spreadSheetData = new List<string[]>() {
+        var spreadSheetData = new List<string[]>() {
                 new string [] { "header 1", "header 2", "header 3" },
                 new string [] { "0001133", "LMW", "123.12" }
             };
 
-            _mockReportGateway
-                .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
-                    It.IsAny<int>()
-                ))
-                .ReturnsAsync(spreadSheetData);
+        _mockReportGateway
+            .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
+                It.IsAny<int>()
+            ))
+            .ReturnsAsync(spreadSheetData);
 
-            var irrelevantFile = RandomGen.Create<GD.File>();
+        var irrelevantFile = RandomGen.Create<GD.File>();
 
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
 
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadCsvFile(
-                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                    It.Is<string>(fn =>
-                        fn.Contains("HB_Academy") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                    ),
-                    It.Is<string>(id => id == housingBenefitAcademyFolder.GoogleIdentifier)
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadCsvFile(
+                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                It.Is<string>(fn =>
+                    fn.Contains("HB_Academy") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
                 ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedHousingBenefitAcademyCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var housingBenefitAcademyFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var spreadSheetData = new List<string[]>();
-
-            _mockReportGateway
-                .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
-                    It.IsAny<int>()
-                ))
-                .ReturnsAsync(spreadSheetData);
-
-            _mockGoogleClientService
-                .Setup(g => g.UploadCsvFile(
-                    It.IsAny<List<string[]>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(true);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFile);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == housingBenefitAcademyFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("HB_Academy") &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
-
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-        #endregion
-        #region Itemised Transactions
-        [Fact]
-        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnoperatingBalancesByRentAccount()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenOperatingBalancesByRentAccountFolderIdIsNotFound()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Output folder not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
-
-            _mockTransactionGateway.Verify(
-                g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()),
-                Times.Never
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCCallsTheTransactionGWGetPRNTransactionsWithApproapriateParametersFromTheReportRequest()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockTransactionGateway.Verify(
-                g => g.GetPRNTransactions(
-                    It.Is<GetPRNTransactionsDomain>(w =>
-                        w.RentGroup == unprocessedReport.RentGroup &&
-                        w.FinancialYear == unprocessedReport.ReportYear.Value &&
-                        w.StartWeekOrMonth == unprocessedReport.ReportStartWeekOrMonth.Value &&
-                        w.EndWeekOrMonth == unprocessedReport.ReportEndWeekOrMonth.Value
-                    )
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCUploadsTheOperatingBalancesByRentAccountDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-            var opBalTransactionData = RandomGen.CreateMany<PRNTransactionDomain>(quantity: 2);
-            var csvStream = CSVHelper.ToCSVStreamFile(opBalTransactionData); // this method is tested & therefore safe
-
-            _mockTransactionGateway
-                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                .ReturnsAsync(opBalTransactionData);
-
-            var irrelevantFile = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(irrelevantFile);
-
-            // act
-            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.UploadFileOrThrow(
-                    It.Is<FileInMemory>(fim =>
-                        Encoding.UTF8.GetString(fim.DataStream.ToArray()) == Encoding.UTF8.GetString(csvStream.ToArray()) &&
-                        fim.Name.Contains("Operating_Balances_by_Rent_Account") &&
-                        fim.Name.Contains(unprocessedReport.RentGroup) &&
-                        fim.Name.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fim.Name.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                        fim.Name.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                        fim.Name.Contains(unprocessedReport.Id.ToString())
-                    ),
-                    It.Is<string>(id => id == operatingBalancesByRentAccountFolder.GoogleIdentifier)
-                ),
-                Times.Once
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCRetrievesTheUploadedOperatingBalancesByRentAccountCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var opBalTransactions = new List<PRNTransactionDomain>();
-
-            _mockTransactionGateway
-                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                .ReturnsAsync(opBalTransactions);
-
-            var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFileRepresentation);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Operating_Balances_by_Rent_Account") &&
-                        fn.Contains(unprocessedReport.RentGroup) &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.AtLeastOnce
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFileRepresentation.Id}"),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Once
-            );
-
-            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-            stepResponse.Should().NotBeNull();
-            stepResponse.Continue.Should().BeTrue();
-            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-        }
-
-        [Fact]
-        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedOperatingBalancesByRentAccountFileIsNotFoundBeforeTheCutoffCheckingTime()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var opBalTransactions = new List<PRNTransactionDomain>();
-
-            _mockTransactionGateway
-                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                .ReturnsAsync(opBalTransactions);
-
-            GD.File uploadedCSVFileRepresentation = null;
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .ReturnsAsync(uploadedCSVFileRepresentation);
-
-            // act
-            Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            await generateAReportCall.Should().NotThrowAsync().ConfigureAwait(false);
-
-            // assert
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.Is<string>(l => l == "Uploaded report file not found"),
-                    It.Is<bool>(s => s == false)
-                ),
-                Times.Once
-            );
-
-            _mockBatchReportGateway.Verify(
-                g => g.SetStatusAsync(
-                    It.Is<int>(id => id == unprocessedReport.Id),
-                    It.IsAny<string>(),
-                    It.Is<bool>(isSuccess => isSuccess == true)
-                ),
-                Times.Never
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var opBalTransactions = new List<PRNTransactionDomain>();
-
-            _mockTransactionGateway
-                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                .ReturnsAsync(opBalTransactions);
-
-            var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-            int expectedNumberOfFileRetrievalAttempts = 30;
-            int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
-            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
-            GD.File fileReturnedFromGDrive = null;
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .Callback(() => fileReturnedFromGDrive = DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFileRepresentation)
-                .ReturnsAsync(fileReturnedFromGDrive);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Operating_Balances_by_Rent_Account") &&
-                        fn.Contains(unprocessedReport.RentGroup) &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.Exactly(expectedNumberOfFileRetrievalAttempts)
-            );
-        }
-
-        [Fact]
-        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
-        {
-            // arrange
-            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-            var unprocessedReport = RandomGen
-                .Build<BatchReportDomain>()
-                .With(r => r.ReportName, requestedReportLabel)
-                .CreateCustom();
-
-            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-            var operatingBalancesByRentAccountFolder = RandomGen
-                .Build<GoogleFileSettingDomain>()
-                .With(f => f.Label, requestedReportLabel)
-                .CreateCustom();
-
-            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-            _mockGoogleFileSettingGateway
-                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                .ReturnsAsync(googleFileSettingsFound);
-
-            var opBalTransactions = new List<PRNTransactionDomain>();
-
-            _mockTransactionGateway
-                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                .ReturnsAsync(opBalTransactions);
-
-            var uploadedCSVFile = RandomGen.Create<GD.File>();
-            int cutOffForNumberOfAttempts = 30;
-            DateTime? firstAttempt = null;
-            DateTime lastAttempt = DateTime.MinValue;
-            GD.File fileReturnedFromGDrive = null;
-
-            _mockGoogleClientService
-                .Setup(g => g.GetFileByNameInDriveAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .Callback(() =>
-                {
-                    firstAttempt ??= DateTime.Now;
-                    lastAttempt = DateTime.Now;
-                })
-                .ReturnsAsync(fileReturnedFromGDrive);
-
-            // act
-            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-            // assert
-            var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
-
-            secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
-
-            _mockGoogleClientService.Verify(
-                g => g.GetFileByNameInDriveAsync(
-                    It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                    It.Is<string>(fn =>
-                        fn.Contains("Operating_Balances_by_Rent_Account") &&
-                        fn.Contains(unprocessedReport.RentGroup) &&
-                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                        fn.Contains(unprocessedReport.Id.ToString())
-                )),
-                Times.Exactly(cutOffForNumberOfAttempts)
-            );
-        }
-        #endregion
+                It.Is<string>(id => id == housingBenefitAcademyFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
     }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedHousingBenefitAcademyCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var housingBenefitAcademyFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var spreadSheetData = new List<string[]>();
+
+        _mockReportGateway
+            .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
+                It.IsAny<int>()
+            ))
+            .ReturnsAsync(spreadSheetData);
+
+        _mockGoogleClientService
+            .Setup(g => g.UploadCsvFile(
+                It.IsAny<List<string[]>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(true);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFile);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == housingBenefitAcademyFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("HB_Academy") &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+    #endregion
+    #region Itemised Transactions
+    [Fact]
+    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnoperatingBalancesByRentAccount()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenOperatingBalancesByRentAccountFolderIdIsNotFound()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Output folder not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockTransactionGateway.Verify(
+            g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCCallsTheTransactionGWGetPRNTransactionsWithApproapriateParametersFromTheReportRequest()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockTransactionGateway.Verify(
+            g => g.GetPRNTransactions(
+                It.Is<GetPRNTransactionsDomain>(w =>
+                    w.RentGroup == unprocessedReport.RentGroup &&
+                    w.FinancialYear == unprocessedReport.ReportYear.Value &&
+                    w.StartWeekOrMonth == unprocessedReport.ReportStartWeekOrMonth.Value &&
+                    w.EndWeekOrMonth == unprocessedReport.ReportEndWeekOrMonth.Value
+                )
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCUploadsTheOperatingBalancesByRentAccountDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+        var opBalTransactionData = RandomGen.CreateMany<PRNTransactionDomain>(quantity: 2);
+        var csvStream = CSVHelper.ToCSVStreamFile(opBalTransactionData); // this method is tested & therefore safe
+
+        _mockTransactionGateway
+            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+            .ReturnsAsync(opBalTransactionData);
+
+        var irrelevantFile = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(irrelevantFile);
+
+        // act
+        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.UploadFileOrThrow(
+                It.Is<FileInMemory>(fim =>
+                    Encoding.UTF8.GetString(fim.DataStream.ToArray()) == Encoding.UTF8.GetString(csvStream.ToArray()) &&
+                    fim.Name.Contains("Operating_Balances_by_Rent_Account") &&
+                    fim.Name.Contains(unprocessedReport.RentGroup) &&
+                    fim.Name.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fim.Name.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                    fim.Name.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                    fim.Name.Contains(unprocessedReport.Id.ToString())
+                ),
+                It.Is<string>(id => id == operatingBalancesByRentAccountFolder.GoogleIdentifier)
+            ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCRetrievesTheUploadedOperatingBalancesByRentAccountCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var opBalTransactions = new List<PRNTransactionDomain>();
+
+        _mockTransactionGateway
+            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+            .ReturnsAsync(opBalTransactions);
+
+        var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFileRepresentation);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Operating_Balances_by_Rent_Account") &&
+                    fn.Contains(unprocessedReport.RentGroup) &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.AtLeastOnce
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFileRepresentation.Id}"),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Once
+        );
+
+        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+        stepResponse.Should().NotBeNull();
+        stepResponse.Continue.Should().BeTrue();
+        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+    }
+
+    [Fact]
+    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedOperatingBalancesByRentAccountFileIsNotFoundBeforeTheCutoffCheckingTime()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var opBalTransactions = new List<PRNTransactionDomain>();
+
+        _mockTransactionGateway
+            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+            .ReturnsAsync(opBalTransactions);
+
+        GD.File uploadedCSVFileRepresentation = null;
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .ReturnsAsync(uploadedCSVFileRepresentation);
+
+        // act
+        Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        await generateAReportCall.Should().NotThrowAsync().ConfigureAwait(false);
+
+        // assert
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.Is<string>(l => l == "Uploaded report file not found"),
+                It.Is<bool>(s => s == false)
+            ),
+            Times.Once
+        );
+
+        _mockBatchReportGateway.Verify(
+            g => g.SetStatusAsync(
+                It.Is<int>(id => id == unprocessedReport.Id),
+                It.IsAny<string>(),
+                It.Is<bool>(isSuccess => isSuccess == true)
+            ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var opBalTransactions = new List<PRNTransactionDomain>();
+
+        _mockTransactionGateway
+            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+            .ReturnsAsync(opBalTransactions);
+
+        var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
+        int expectedNumberOfFileRetrievalAttempts = 30;
+        int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
+        var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
+        GD.File fileReturnedFromGDrive = null;
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .Callback(() => fileReturnedFromGDrive = DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFileRepresentation)
+            .ReturnsAsync(fileReturnedFromGDrive);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Operating_Balances_by_Rent_Account") &&
+                    fn.Contains(unprocessedReport.RentGroup) &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.Exactly(expectedNumberOfFileRetrievalAttempts)
+        );
+    }
+
+    [Fact]
+    public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
+    {
+        // arrange
+        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+        var unprocessedReport = RandomGen
+            .Build<BatchReportDomain>()
+            .With(r => r.ReportName, requestedReportLabel)
+            .CreateCustom();
+
+        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+        var operatingBalancesByRentAccountFolder = RandomGen
+            .Build<GoogleFileSettingDomain>()
+            .With(f => f.Label, requestedReportLabel)
+            .CreateCustom();
+
+        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+        _mockGoogleFileSettingGateway
+            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+            .ReturnsAsync(googleFileSettingsFound);
+
+        var opBalTransactions = new List<PRNTransactionDomain>();
+
+        _mockTransactionGateway
+            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+            .ReturnsAsync(opBalTransactions);
+
+        var uploadedCSVFile = RandomGen.Create<GD.File>();
+        int cutOffForNumberOfAttempts = 30;
+        DateTime? firstAttempt = null;
+        DateTime lastAttempt = DateTime.MinValue;
+        GD.File fileReturnedFromGDrive = null;
+
+        _mockGoogleClientService
+            .Setup(g => g.GetFileByNameInDriveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>()
+            ))
+            .Callback(() =>
+            {
+                firstAttempt ??= DateTime.Now;
+                lastAttempt = DateTime.Now;
+            })
+            .ReturnsAsync(fileReturnedFromGDrive);
+
+        // act
+        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+        // assert
+        var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+
+        secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+
+        _mockGoogleClientService.Verify(
+            g => g.GetFileByNameInDriveAsync(
+                It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                It.Is<string>(fn =>
+                    fn.Contains("Operating_Balances_by_Rent_Account") &&
+                    fn.Contains(unprocessedReport.RentGroup) &&
+                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                    fn.Contains(unprocessedReport.Id.ToString())
+            )),
+            Times.Exactly(cutOffForNumberOfAttempts)
+        );
+    }
+    #endregion
 }
+

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -3074,24 +3074,6 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             DateTime lastAttempt = DateTime.MinValue;
             GD.File fileReturnedFromGDrive = null;
 
-            // _mockGoogleClientService
-            //     .Setup(g => g.GetFileByNameInDriveAsync(
-            //         It.IsAny<string>(),
-            //         It.IsAny<string>()
-            //     ))
-            //     .Callback(() =>
-            //     {
-            //         firstAttempt ??= DateTime.Now;
-            //         lastAttempt = DateTime.Now;
-            //     })
-            //     .ReturnsAsync(fileReturnedFromGDrive);
-            // act
-
-            // var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-            //
-            // // assert
-            // var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
-
             _mockGoogleClientService
                 .Setup(g => g.GetFileByNameInDriveAsync(
                     It.IsAny<string>(),

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -1718,7 +1718,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         }
 
         [Fact]
-        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
+        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterReachingTheWaitDuration()
         {
             // arrange
             var requestedReportLabel = "ReportItemisedTransactions";
@@ -2974,7 +2974,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         }
 
         [Fact]
-        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdEveryRetryIntervalUntilTheWaitDuration()
         {
             // arrange
             var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
@@ -3037,7 +3037,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         }
 
         [Fact]
-        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
+        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterReachingTheWaitDuration()
         {
             // arrange
             var requestedReportLabel = "ReportOperatingBalancesByRentAccount";

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -42,7 +42,8 @@ public class GenerateReportUseCaseTests
                 _mockReportGateway.Object,
                 _mockTransactionGateway.Object,
                 _mockGoogleFileSettingGateway.Object,
-                _mockGoogleClientService.Object
+                _mockGoogleClientService.Object,
+                1000
             );
     }
 
@@ -168,7 +169,7 @@ public class GenerateReportUseCaseTests
         Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
         // assert
-        await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message);
+        await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message).ConfigureAwait(false);
     }
     #endregion
 

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -3087,9 +3087,9 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
             // assert
-            var secondsSpentInWaitForTheFile = (lastAttempt - firstAttempt).Value.TotalSeconds + (_retryInterval / 1000);
+            var secondsSpentInWaitForTheFile = (lastAttempt - firstAttempt).Value.TotalSeconds + (_retryInterval / 1000.0);
 
-            Math.Round(secondsSpentInWaitForTheFile, 2).Should().Be((double) (_waitDuration - _retryInterval) / 1000);
+            Math.Round(secondsSpentInWaitForTheFile, 2).Should().Be(_waitDuration / 1000.0);
 
             _mockGoogleClientService.Verify(
                 g => g.GetFileByNameInDriveAsync(

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -1782,7 +1782,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             Assert.True(firstAttempt.HasValue);
             var secondsSpentInWaitForTheFile = (lastAttempt - firstAttempt).Value.TotalSeconds + (_retryInterval / 1000.0);
 
-            Math.Round(secondsSpentInWaitForTheFile, 2).Should().Be( _waitDuration / 1000.0);
+            Math.Round(secondsSpentInWaitForTheFile, 2).Should().Be(_waitDuration / 1000.0);
 
             _mockGoogleClientService.Verify(
                 g => g.GetFileByNameInDriveAsync(

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -16,3107 +16,3118 @@ using FluentAssertions.Common;
 using System.Text;
 using HousingFinanceInterimApi.V1.Boundary.Response;
 
-namespace HousingFinanceInterimApi.Tests.V1.UseCase;
-
-public class GenerateReportUseCaseTests
+namespace HousingFinanceInterimApi.Tests.V1.UseCase
 {
-    private readonly Mock<IBatchReportGateway> _mockBatchReportGateway;
-    private readonly Mock<IReportGateway> _mockReportGateway;
-    private readonly Mock<ITransactionGateway> _mockTransactionGateway;
-    private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
-    private readonly Mock<IGoogleClientService> _mockGoogleClientService;
-    private readonly int _waitDuration = 3000; // 3 seconds
-    private readonly int _retryInterval = 200; // 0.2 seconds
-    private readonly IGenerateReportUseCase _classUnderTest;
-
-    public GenerateReportUseCaseTests()
-    {
-        _mockBatchReportGateway = new Mock<IBatchReportGateway>();
-        _mockReportGateway = new Mock<IReportGateway>();
-        _mockTransactionGateway = new();
-        _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
-        _mockGoogleClientService = new Mock<IGoogleClientService>();
-
-        Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
-
-        _classUnderTest = new GenerateReportUseCase(
-                _mockBatchReportGateway.Object,
-                _mockReportGateway.Object,
-                _mockTransactionGateway.Object,
-                _mockGoogleFileSettingGateway.Object,
-                _mockGoogleClientService.Object,
-                _waitDuration,
-                _retryInterval
-            );
-    }
-
-    #region Shared
-    [Fact]
-    public async Task GenerateReportUCChecksWhetherAnyUnprocessedReportRequestsExist()
-    {
-        // arrange
-        var unprocessedReports = new List<BatchReportDomain>();
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(g => g.ListPendingAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenThereAreNoReportRequestsToProcess()
-    {
-        // arrange
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-        var unprocessedReports = new List<BatchReportDomain>();
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeFalse();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenTheRequestedReportNameFoundIsUnknown()
-    {
-        // arrange
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        var unknownTypeUnprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, "Pepsi > CocaCola")
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unknownTypeUnprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCStartsGeneratingTheEarliestRequestedReportInTheQueue()
-    {
-        // arrange
-        var expectedearliestReportLabel = "ReportItemisedTransactions";
-
-        var earliestRequestedUnprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, expectedearliestReportLabel)
-            .With(r => r.StartTime, DateTime.Now.AddMinutes(-20))
-            .CreateCustom();
-
-        var lastRequestedUnprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, "ReportCashSuspense")
-            .With(r => r.StartTime, DateTime.Now)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { lastRequestedUnprocessedReport, earliestRequestedUnprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var accountBalanceFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, expectedearliestReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == expectedearliestReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCThrowsAnExceptionWheneverOneIsRaisedWithinIt()
-    {
-        // arrange
-        var message = "The premise of the argument is incorrect.";
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ThrowsAsync(new ArgumentException(message));
-
-        // act
-        Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message).ConfigureAwait(false);
-    }
-    #endregion
-
-    #region Account Balance
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnAccountBalance()
-    {
-        // arrange
-        var requestedReportLabel = "ReportAccountBalanceByDate";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var accountBalanceFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenAccountBalanceFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportAccountBalanceByDate";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetReportAccountBalanceAsync(
-                It.IsAny<DateTime>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithDateTimeAndRentGroupFromTheReportRequestAlsoTheCreatedFileNameIsHasTrimmedRentGroup()
-    {
-        // arrange
-        var requestedRentGroup = "HRA";
-        var untrimmedRentGroup = $"  {requestedRentGroup} ";
-        var requestedReportLabel = "ReportAccountBalanceByDate";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, untrimmedRentGroup)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var accountBalanceFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetReportAccountBalanceAsync(
-                It.Is<DateTime>(d => d.Equals(unprocessedReport.ReportDate.Value)),
-                It.Is<string>(r => r == untrimmedRentGroup) // Odd, but that's the current behaviour.
-            ),
-            Times.Once
-        );
-
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.Is<string>(fn =>
-                    !fn.Contains(untrimmedRentGroup) &&
-                    fn.Contains(requestedRentGroup)
-                ),
-                It.IsAny<string>()
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithRentGroupValueSetAsNullButTheUploadedFileNameContainsTheValueALLWhenRentGroupIsNotProvided()
-    {
-        // arrange
-        var requestedReportLabel = "ReportAccountBalanceByDate";
-
-        string requestedRentGroup = null;
-        var allRentGroups = "ALL";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, requestedRentGroup)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var accountBalanceFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetReportAccountBalanceAsync(
-                It.IsAny<DateTime>(),
-                It.Is<string>(r => r == requestedRentGroup)
-            ),
-            Times.Once
-        );
-
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.Is<string>(fn => fn.Contains(allRentGroups)),
-                It.IsAny<string>()
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheAccountBalanceDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-    {
-        // arrange
-        var requestedReportLabel = "ReportAccountBalanceByDate";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var accountBalanceFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3", "header 4" },
-                new string [] { "0008425", "HRA", "520.36", "2020-08-08" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetReportAccountBalanceAsync(
-                It.IsAny<DateTime>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn => fn.Contains("Account_Balance")),
-                It.Is<string>(id => id == accountBalanceFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedAccountBalanceCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportAccountBalanceByDate";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var accountBalanceFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetReportAccountBalanceAsync(
-                It.IsAny<DateTime>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == accountBalanceFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Account_Balance") &&
-                    fn.Contains(unprocessedReport.RentGroup) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-    #endregion
-
-    #region Charges
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsCharges()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenChargesFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAndRentGroupAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByGroupTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAsync(
-                It.IsAny<int>()
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetChargesByYearAndRentGroupWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheRentGroupIsNonEmpty()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAndRentGroupAsync(
-                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                It.Is<string>(r => r == unprocessedReport.RentGroup)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByGroupTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAsync(
-                It.IsAny<int>()
-            ),
-            Times.Never
-        );
-
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.Is<string>(fn =>
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.RentGroup) &&
-                    !fn.Contains(unprocessedReport.Group)
-                ),
-                It.IsAny<string>()
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetChargesByGroupTypeWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheGroupIsNonEmptyButTheRentGroupIsEmpty()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, null as string)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAndRentGroupAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByGroupTypeAsync(
-                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                It.Is<string>(r => r == unprocessedReport.Group)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAsync(
-                It.IsAny<int>()
-            ),
-            Times.Never
-        );
-
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.Is<string>(fn =>
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Group)
-                ),
-                It.IsAny<string>()
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetChargesByYearWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenBothTheGroupAndTheRentGroupAreEmpty()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, null as string)
-            .With(r => r.Group, null as string)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAndRentGroupAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByGroupTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetChargesByYearAsync(
-                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value))
-            ),
-            Times.Once
-        );
-
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.Is<string>(fn =>
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString())
-                ),
-                It.IsAny<string>()
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheChargesByYearAndRentGroupDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3", "header 4" },
-                new string [] { "0001234", "TRA", "130.36", "2025-01-06" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetChargesByYearAndRentGroupAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn => fn.Contains("Charges")),
-                It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheChargesByGroupTypeDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, null as string)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3", "header 4" },
-                new string [] { "0022455", "LSC", "7.88", "2023-04-22" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetChargesByGroupTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn => fn.Contains("Charges")),
-                It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheChargesByYearDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, null as string)
-            .With(r => r.Group, null as string)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3", "header 4" },
-                new string [] { "0004567", "LMW", "70.11", "2015-02-14" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetChargesByYearAsync(
-                It.IsAny<int>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn => fn.Contains("Charges")),
-                It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedChargesByYearAndRentGroupCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetChargesByYearAndRentGroupAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Charges") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.RentGroup.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedChargesByGroupTypeCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, null as string)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetChargesByGroupTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Charges") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Group.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedChargesByYearCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCharges";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .With(r => r.RentGroup, null as string)
-            .With(r => r.Group, null as string)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var chargesFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetChargesByYearAsync(
-                It.IsAny<int>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        var expectedNextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Charges") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(expectedNextStepTime, 1500);
-    }
-    #endregion
-
-    #region Itemised Transactions
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnItemisedTransactions()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenItemisedTransactionFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetItemisedTransactionsByYearAndTransactionTypeWithApproapriateParametersFromTheReportRequest()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.Is<int>(y => y == unprocessedReport.ReportYear.Value),
-                It.Is<string>(t => t == unprocessedReport.TransactionType)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheItemisedTransactionsDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3" },
-                new string [] { "00088255", "LMW", "251.23" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn =>
-                    fn.Contains("Itemised_Transactions") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.TransactionType) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-                ),
-                It.Is<string>(id => id == itemisedTransactionsFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedItemisedTransactionsCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Itemised_Transactions") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.TransactionType) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedItemisedTransactionsFileIsNotFoundBeforeTheCutoffCheckingTime()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        GD.File uploadedCSVFile = null;
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        await generateAReportCall.Should().NotThrowAsync();
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Uploaded report file not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.IsAny<string>(),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-        var secondsUntilFileAvailable = 2;
-        int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
-        var fileAvailabilityTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(() =>
+        public class GenerateReportUseCaseTests
+        {
+            private readonly Mock<IBatchReportGateway> _mockBatchReportGateway;
+            private readonly Mock<IReportGateway> _mockReportGateway;
+            private readonly Mock<ITransactionGateway> _mockTransactionGateway;
+            private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
+            private readonly Mock<IGoogleClientService> _mockGoogleClientService;
+            private readonly int _waitDuration = 3000; // 3 seconds
+            private readonly int _retryInterval = 200; // 0.2 seconds
+            private readonly IGenerateReportUseCase _classUnderTest;
+
+            public GenerateReportUseCaseTests()
             {
-                return DateTime.Now < fileAvailabilityTime ? null : uploadedCSVFile;
-            });
+                _mockBatchReportGateway = new Mock<IBatchReportGateway>();
+                _mockReportGateway = new Mock<IReportGateway>();
+                _mockTransactionGateway = new();
+                _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
+                _mockGoogleClientService = new Mock<IGoogleClientService>();
 
+                Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
 
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+                _classUnderTest = new GenerateReportUseCase(
+                        _mockBatchReportGateway.Object,
+                        _mockReportGateway.Object,
+                        _mockTransactionGateway.Object,
+                        _mockGoogleFileSettingGateway.Object,
+                        _mockGoogleClientService.Object,
+                        _waitDuration,
+                        _retryInterval
+                    );
+            }
 
-        // assert
-        Assert.True(stepResponse.Continue);
-
-
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Itemised_Transactions") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.TransactionType) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.Exactly(expectedNumberOfFileRetrievalAttempts)
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
-    {
-        // arrange
-        var requestedReportLabel = "ReportItemisedTransactions";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var itemisedTransactionsFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-        int cutOffForNumberOfAttempts = 30;
-        DateTime? firstAttempt = null;
-        DateTime lastAttempt = DateTime.MinValue;
-        GD.File fileReturnedFromGDrive = null;
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .Callback(() =>
+            #region Shared
+            [Fact]
+            public async Task GenerateReportUCChecksWhetherAnyUnprocessedReportRequestsExist()
             {
-                firstAttempt ??= DateTime.Now;
-                lastAttempt = DateTime.Now;
-            })
-            .ReturnsAsync(fileReturnedFromGDrive);
+                // arrange
+                var unprocessedReports = new List<BatchReportDomain>();
 
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-        // assert
-        var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-        secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+                // assert
+                _mockBatchReportGateway.Verify(g => g.ListPendingAsync(), Times.Once);
+            }
 
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Itemised_Transactions") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.TransactionType) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.Exactly(cutOffForNumberOfAttempts)
-        );
-    }
-    #endregion
-
-    #region Cash Suspense
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashSuspense()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashSuspense";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashSuspenseFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashSuspenseFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashSuspense";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetCashSuspenseAccountByYearAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetCashSuspenseAccountByYearWithApproapriateParametersFromTheReportRequest()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashSuspense";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashSuspenseFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetCashSuspenseAccountByYearAsync(
-                It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                It.Is<string>(r => r == unprocessedReport.Group)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheCashSuspenseDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashSuspense";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashSuspenseFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3" },
-                new string [] { "0000112", "TRA", "0.01" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetCashSuspenseAccountByYearAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn =>
-                    fn.Contains("Cash_Suspense") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Group) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-                ),
-                It.Is<string>(id => id == cashSuspenseFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedCashSuspenseCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashSuspense";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashSuspenseFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetCashSuspenseAccountByYearAsync(
-                It.IsAny<int>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == cashSuspenseFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Cash_Suspense") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Group) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-    #endregion
-
-    #region Cash Import
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashImport()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashImport";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashImportFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashImportFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashImport";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetCashImportByDateAsync(
-                It.IsAny<DateTime>(),
-                It.IsAny<DateTime>()
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetCashImportByDateWithApproapriateParametersFromTheReportRequest()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashImport";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashImportFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetCashImportByDateAsync(
-                It.Is<DateTime>(s => s.Equals(unprocessedReport.ReportStartDate.Value)),
-                It.Is<DateTime>(e => e.Equals(unprocessedReport.ReportEndDate.Value))
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheCashImportDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashImport";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashImportFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3" },
-                new string [] { "0000223", "LSC", "3.01" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetCashImportByDateAsync(
-                It.IsAny<DateTime>(),
-                It.IsAny<DateTime>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn =>
-                    fn.Contains("Cash_Import") &&
-                    fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
-                    fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-                ),
-                It.Is<string>(id => id == cashImportFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedCashImportCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportCashImport";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var cashImportFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetCashImportByDateAsync(
-                It.IsAny<DateTime>(),
-                It.IsAny<DateTime>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == cashImportFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Cash_Import") &&
-                    fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
-                    fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-    #endregion
-
-    #region Housing Benefit Academy
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAHousingBenefitAcademy()
-    {
-        // arrange
-        var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var housingBenefitAcademyFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenHousingBenefitAcademyFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockReportGateway.Verify(
-            g => g.GetHousingBenefitAcademyByYearAsync(
-                It.IsAny<int>()
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheReportGWGetHousingBenefitAcademyByYearWithApproapriateParametersFromTheReportRequest()
-    {
-        // arrange
-        var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var housingBenefitAcademyFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockReportGateway.Verify(
-            g => g.GetHousingBenefitAcademyByYearAsync(
-                It.Is<int>(s => s.Equals(unprocessedReport.ReportYear.Value))
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheHousingBenefitAcademyDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-    {
-        // arrange
-        var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var housingBenefitAcademyFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>() {
-                new string [] { "header 1", "header 2", "header 3" },
-                new string [] { "0001133", "LMW", "123.12" }
-            };
-
-        _mockReportGateway
-            .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
-                It.IsAny<int>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadCsvFile(
-                It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                It.Is<string>(fn =>
-                    fn.Contains("HB_Academy") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-                ),
-                It.Is<string>(id => id == housingBenefitAcademyFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedHousingBenefitAcademyCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var housingBenefitAcademyFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var spreadSheetData = new List<string[]>();
-
-        _mockReportGateway
-            .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
-                It.IsAny<int>()
-            ))
-            .ReturnsAsync(spreadSheetData);
-
-        _mockGoogleClientService
-            .Setup(g => g.UploadCsvFile(
-                It.IsAny<List<string[]>>(),
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(true);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFile);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == housingBenefitAcademyFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("HB_Academy") &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-    #endregion
-    #region Itemised Transactions
-    [Fact]
-    public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnoperatingBalancesByRentAccount()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenOperatingBalancesByRentAccountFolderIdIsNotFound()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Output folder not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockTransactionGateway.Verify(
-            g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCCallsTheTransactionGWGetPRNTransactionsWithApproapriateParametersFromTheReportRequest()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockTransactionGateway.Verify(
-            g => g.GetPRNTransactions(
-                It.Is<GetPRNTransactionsDomain>(w =>
-                    w.RentGroup == unprocessedReport.RentGroup &&
-                    w.FinancialYear == unprocessedReport.ReportYear.Value &&
-                    w.StartWeekOrMonth == unprocessedReport.ReportStartWeekOrMonth.Value &&
-                    w.EndWeekOrMonth == unprocessedReport.ReportEndWeekOrMonth.Value
-                )
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCUploadsTheOperatingBalancesByRentAccountDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-        var opBalTransactionData = RandomGen.CreateMany<PRNTransactionDomain>(quantity: 2);
-        var csvStream = CSVHelper.ToCSVStreamFile(opBalTransactionData); // this method is tested & therefore safe
-
-        _mockTransactionGateway
-            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-            .ReturnsAsync(opBalTransactionData);
-
-        var irrelevantFile = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(irrelevantFile);
-
-        // act
-        await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.UploadFileOrThrow(
-                It.Is<FileInMemory>(fim =>
-                    Encoding.UTF8.GetString(fim.DataStream.ToArray()) == Encoding.UTF8.GetString(csvStream.ToArray()) &&
-                    fim.Name.Contains("Operating_Balances_by_Rent_Account") &&
-                    fim.Name.Contains(unprocessedReport.RentGroup) &&
-                    fim.Name.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fim.Name.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                    fim.Name.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                    fim.Name.Contains(unprocessedReport.Id.ToString())
-                ),
-                It.Is<string>(id => id == operatingBalancesByRentAccountFolder.GoogleIdentifier)
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCRetrievesTheUploadedOperatingBalancesByRentAccountCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var opBalTransactions = new List<PRNTransactionDomain>();
-
-        _mockTransactionGateway
-            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-            .ReturnsAsync(opBalTransactions);
-
-        var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFileRepresentation);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Operating_Balances_by_Rent_Account") &&
-                    fn.Contains(unprocessedReport.RentGroup) &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.AtLeastOnce
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFileRepresentation.Id}"),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Once
-        );
-
-        var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-        stepResponse.Should().NotBeNull();
-        stepResponse.Continue.Should().BeTrue();
-        stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-    }
-
-    [Fact]
-    public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedOperatingBalancesByRentAccountFileIsNotFoundBeforeTheCutoffCheckingTime()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var opBalTransactions = new List<PRNTransactionDomain>();
-
-        _mockTransactionGateway
-            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-            .ReturnsAsync(opBalTransactions);
-
-        GD.File uploadedCSVFileRepresentation = null;
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .ReturnsAsync(uploadedCSVFileRepresentation);
-
-        // act
-        Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        await generateAReportCall.Should().NotThrowAsync().ConfigureAwait(false);
-
-        // assert
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.Is<string>(l => l == "Uploaded report file not found"),
-                It.Is<bool>(s => s == false)
-            ),
-            Times.Once
-        );
-
-        _mockBatchReportGateway.Verify(
-            g => g.SetStatusAsync(
-                It.Is<int>(id => id == unprocessedReport.Id),
-                It.IsAny<string>(),
-                It.Is<bool>(isSuccess => isSuccess == true)
-            ),
-            Times.Never
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var opBalTransactions = new List<PRNTransactionDomain>();
-
-        _mockTransactionGateway
-            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-            .ReturnsAsync(opBalTransactions);
-
-        var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-        int expectedNumberOfFileRetrievalAttempts = 30;
-        int csvUploadDelaySeconds = expectedNumberOfFileRetrievalAttempts;
-        var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(csvUploadDelaySeconds);
-        GD.File fileReturnedFromGDrive = null;
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .Callback(() => fileReturnedFromGDrive = DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFileRepresentation)
-            .ReturnsAsync(fileReturnedFromGDrive);
-
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-        // assert
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Operating_Balances_by_Rent_Account") &&
-                    fn.Contains(unprocessedReport.RentGroup) &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.Exactly(expectedNumberOfFileRetrievalAttempts)
-        );
-    }
-
-    [Fact]
-    public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
-    {
-        // arrange
-        var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-        var unprocessedReport = RandomGen
-            .Build<BatchReportDomain>()
-            .With(r => r.ReportName, requestedReportLabel)
-            .CreateCustom();
-
-        var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-        _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-        var operatingBalancesByRentAccountFolder = RandomGen
-            .Build<GoogleFileSettingDomain>()
-            .With(f => f.Label, requestedReportLabel)
-            .CreateCustom();
-
-        var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-        _mockGoogleFileSettingGateway
-            .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-            .ReturnsAsync(googleFileSettingsFound);
-
-        var opBalTransactions = new List<PRNTransactionDomain>();
-
-        _mockTransactionGateway
-            .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-            .ReturnsAsync(opBalTransactions);
-
-        var uploadedCSVFile = RandomGen.Create<GD.File>();
-        int cutOffForNumberOfAttempts = 30;
-        DateTime? firstAttempt = null;
-        DateTime lastAttempt = DateTime.MinValue;
-        GD.File fileReturnedFromGDrive = null;
-
-        _mockGoogleClientService
-            .Setup(g => g.GetFileByNameInDriveAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>()
-            ))
-            .Callback(() =>
+            [Fact]
+            public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenThereAreNoReportRequestsToProcess()
             {
-                firstAttempt ??= DateTime.Now;
-                lastAttempt = DateTime.Now;
-            })
-            .ReturnsAsync(fileReturnedFromGDrive);
+                // arrange
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+                var unprocessedReports = new List<BatchReportDomain>();
 
-        // act
-        var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-        // assert
-        var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-        secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
 
-        _mockGoogleClientService.Verify(
-            g => g.GetFileByNameInDriveAsync(
-                It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                It.Is<string>(fn =>
-                    fn.Contains("Operating_Balances_by_Rent_Account") &&
-                    fn.Contains(unprocessedReport.RentGroup) &&
-                    fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                    fn.Contains(unprocessedReport.Id.ToString())
-            )),
-            Times.Exactly(cutOffForNumberOfAttempts)
-        );
-    }
-    #endregion
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeFalse();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenTheRequestedReportNameFoundIsUnknown()
+            {
+                // arrange
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                var unknownTypeUnprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, "Pepsi > CocaCola")
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unknownTypeUnprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCStartsGeneratingTheEarliestRequestedReportInTheQueue()
+            {
+                // arrange
+                var expectedearliestReportLabel = "ReportItemisedTransactions";
+
+                var earliestRequestedUnprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, expectedearliestReportLabel)
+                    .With(r => r.StartTime, DateTime.Now.AddMinutes(-20))
+                    .CreateCustom();
+
+                var lastRequestedUnprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, "ReportCashSuspense")
+                    .With(r => r.StartTime, DateTime.Now)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { lastRequestedUnprocessedReport, earliestRequestedUnprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var accountBalanceFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, expectedearliestReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == expectedearliestReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCThrowsAnExceptionWheneverOneIsRaisedWithinIt()
+            {
+                // arrange
+                var message = "The premise of the argument is incorrect.";
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ThrowsAsync(new ArgumentException(message));
+
+                // act
+                Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message).ConfigureAwait(false);
+            }
+            #endregion
+
+            #region Account Balance
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnAccountBalance()
+            {
+                // arrange
+                var requestedReportLabel = "ReportAccountBalanceByDate";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var accountBalanceFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenAccountBalanceFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportAccountBalanceByDate";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetReportAccountBalanceAsync(
+                        It.IsAny<DateTime>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithDateTimeAndRentGroupFromTheReportRequestAlsoTheCreatedFileNameIsHasTrimmedRentGroup()
+            {
+                // arrange
+                var requestedRentGroup = "HRA";
+                var untrimmedRentGroup = $"  {requestedRentGroup} ";
+                var requestedReportLabel = "ReportAccountBalanceByDate";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, untrimmedRentGroup)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var accountBalanceFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetReportAccountBalanceAsync(
+                        It.Is<DateTime>(d => d.Equals(unprocessedReport.ReportDate.Value)),
+                        It.Is<string>(r => r == untrimmedRentGroup) // Odd, but that's the current behaviour.
+                    ),
+                    Times.Once
+                );
+
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.Is<string>(fn =>
+                            !fn.Contains(untrimmedRentGroup) &&
+                            fn.Contains(requestedRentGroup)
+                        ),
+                        It.IsAny<string>()
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithRentGroupValueSetAsNullButTheUploadedFileNameContainsTheValueALLWhenRentGroupIsNotProvided()
+            {
+                // arrange
+                var requestedReportLabel = "ReportAccountBalanceByDate";
+
+                string requestedRentGroup = null;
+                var allRentGroups = "ALL";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, requestedRentGroup)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var accountBalanceFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetReportAccountBalanceAsync(
+                        It.IsAny<DateTime>(),
+                        It.Is<string>(r => r == requestedRentGroup)
+                    ),
+                    Times.Once
+                );
+
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.Is<string>(fn => fn.Contains(allRentGroups)),
+                        It.IsAny<string>()
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheAccountBalanceDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+            {
+                // arrange
+                var requestedReportLabel = "ReportAccountBalanceByDate";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var accountBalanceFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3", "header 4" },
+                        new string [] { "0008425", "HRA", "520.36", "2020-08-08" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetReportAccountBalanceAsync(
+                        It.IsAny<DateTime>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn => fn.Contains("Account_Balance")),
+                        It.Is<string>(id => id == accountBalanceFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedAccountBalanceCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportAccountBalanceByDate";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var accountBalanceFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetReportAccountBalanceAsync(
+                        It.IsAny<DateTime>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == accountBalanceFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Account_Balance") &&
+                            fn.Contains(unprocessedReport.RentGroup) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+            #endregion
+
+            #region Charges
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsCharges()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenChargesFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAndRentGroupAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByGroupTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAsync(
+                        It.IsAny<int>()
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetChargesByYearAndRentGroupWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheRentGroupIsNonEmpty()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAndRentGroupAsync(
+                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                        It.Is<string>(r => r == unprocessedReport.RentGroup)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByGroupTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAsync(
+                        It.IsAny<int>()
+                    ),
+                    Times.Never
+                );
+
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.Is<string>(fn =>
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.RentGroup) &&
+                            !fn.Contains(unprocessedReport.Group)
+                        ),
+                        It.IsAny<string>()
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetChargesByGroupTypeWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheGroupIsNonEmptyButTheRentGroupIsEmpty()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, null as string)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAndRentGroupAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByGroupTypeAsync(
+                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                        It.Is<string>(r => r == unprocessedReport.Group)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAsync(
+                        It.IsAny<int>()
+                    ),
+                    Times.Never
+                );
+
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.Is<string>(fn =>
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Group)
+                        ),
+                        It.IsAny<string>()
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetChargesByYearWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenBothTheGroupAndTheRentGroupAreEmpty()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, null as string)
+                    .With(r => r.Group, null as string)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAndRentGroupAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByGroupTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetChargesByYearAsync(
+                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value))
+                    ),
+                    Times.Once
+                );
+
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.Is<string>(fn =>
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString())
+                        ),
+                        It.IsAny<string>()
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheChargesByYearAndRentGroupDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3", "header 4" },
+                        new string [] { "0001234", "TRA", "130.36", "2025-01-06" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetChargesByYearAndRentGroupAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn => fn.Contains("Charges")),
+                        It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheChargesByGroupTypeDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, null as string)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3", "header 4" },
+                        new string [] { "0022455", "LSC", "7.88", "2023-04-22" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetChargesByGroupTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn => fn.Contains("Charges")),
+                        It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheChargesByYearDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, null as string)
+                    .With(r => r.Group, null as string)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3", "header 4" },
+                        new string [] { "0004567", "LMW", "70.11", "2015-02-14" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetChargesByYearAsync(
+                        It.IsAny<int>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn => fn.Contains("Charges")),
+                        It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedChargesByYearAndRentGroupCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetChargesByYearAndRentGroupAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Charges") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.RentGroup.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedChargesByGroupTypeCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, null as string)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetChargesByGroupTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Charges") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Group.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedChargesByYearCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCharges";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .With(r => r.RentGroup, null as string)
+                    .With(r => r.Group, null as string)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var chargesFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetChargesByYearAsync(
+                        It.IsAny<int>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                var expectedNextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Charges") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(expectedNextStepTime, 1500);
+            }
+            #endregion
+
+            #region Itemised Transactions
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnItemisedTransactions()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenItemisedTransactionFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetItemisedTransactionsByYearAndTransactionTypeWithApproapriateParametersFromTheReportRequest()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.Is<int>(y => y == unprocessedReport.ReportYear.Value),
+                        It.Is<string>(t => t == unprocessedReport.TransactionType)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheItemisedTransactionsDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3" },
+                        new string [] { "00088255", "LMW", "251.23" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn =>
+                            fn.Contains("Itemised_Transactions") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.TransactionType) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                        ),
+                        It.Is<string>(id => id == itemisedTransactionsFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedItemisedTransactionsCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Itemised_Transactions") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.TransactionType) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedItemisedTransactionsFileIsNotFoundBeforeTheCutoffCheckingTime()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                GD.File uploadedCSVFile = null;
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                await generateAReportCall.Should().NotThrowAsync();
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Uploaded report file not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.IsAny<string>(),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+                var secondsUntilFileAvailable = 2;
+                int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
+                var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(() => DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFile);
+
+
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                Assert.True(stepResponse.Continue);
+
+
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Itemised_Transactions") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.TransactionType) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.Exactly(expectedNumberOfFileRetrievalAttempts)
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
+            {
+                // arrange
+                var requestedReportLabel = "ReportItemisedTransactions";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var itemisedTransactionsFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+                int cutOffForNumberOfAttempts = 30;
+                DateTime? firstAttempt = null;
+                DateTime lastAttempt = DateTime.MinValue;
+                GD.File fileReturnedFromGDrive = null;
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .Callback(() =>
+                    {
+                        firstAttempt ??= DateTime.Now;
+                        lastAttempt = DateTime.Now;
+                    })
+                    .ReturnsAsync(fileReturnedFromGDrive);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+
+                secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Itemised_Transactions") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.TransactionType) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.Exactly(cutOffForNumberOfAttempts)
+                );
+            }
+            #endregion
+
+            #region Cash Suspense
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashSuspense()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashSuspense";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashSuspenseFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashSuspenseFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashSuspense";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetCashSuspenseAccountByYearAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetCashSuspenseAccountByYearWithApproapriateParametersFromTheReportRequest()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashSuspense";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashSuspenseFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetCashSuspenseAccountByYearAsync(
+                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                        It.Is<string>(r => r == unprocessedReport.Group)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheCashSuspenseDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashSuspense";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashSuspenseFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3" },
+                        new string [] { "0000112", "TRA", "0.01" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetCashSuspenseAccountByYearAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn =>
+                            fn.Contains("Cash_Suspense") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Group) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                        ),
+                        It.Is<string>(id => id == cashSuspenseFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedCashSuspenseCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashSuspense";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashSuspenseFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetCashSuspenseAccountByYearAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == cashSuspenseFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Cash_Suspense") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Group) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+            #endregion
+
+            #region Cash Import
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashImport()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashImport";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashImportFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashImportFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashImport";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetCashImportByDateAsync(
+                        It.IsAny<DateTime>(),
+                        It.IsAny<DateTime>()
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetCashImportByDateWithApproapriateParametersFromTheReportRequest()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashImport";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashImportFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetCashImportByDateAsync(
+                        It.Is<DateTime>(s => s.Equals(unprocessedReport.ReportStartDate.Value)),
+                        It.Is<DateTime>(e => e.Equals(unprocessedReport.ReportEndDate.Value))
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheCashImportDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashImport";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashImportFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3" },
+                        new string [] { "0000223", "LSC", "3.01" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetCashImportByDateAsync(
+                        It.IsAny<DateTime>(),
+                        It.IsAny<DateTime>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn =>
+                            fn.Contains("Cash_Import") &&
+                            fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
+                            fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                        ),
+                        It.Is<string>(id => id == cashImportFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedCashImportCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportCashImport";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var cashImportFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetCashImportByDateAsync(
+                        It.IsAny<DateTime>(),
+                        It.IsAny<DateTime>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == cashImportFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Cash_Import") &&
+                            fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
+                            fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+            #endregion
+
+            #region Housing Benefit Academy
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAHousingBenefitAcademy()
+            {
+                // arrange
+                var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var housingBenefitAcademyFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenHousingBenefitAcademyFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockReportGateway.Verify(
+                    g => g.GetHousingBenefitAcademyByYearAsync(
+                        It.IsAny<int>()
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheReportGWGetHousingBenefitAcademyByYearWithApproapriateParametersFromTheReportRequest()
+            {
+                // arrange
+                var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var housingBenefitAcademyFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockReportGateway.Verify(
+                    g => g.GetHousingBenefitAcademyByYearAsync(
+                        It.Is<int>(s => s.Equals(unprocessedReport.ReportYear.Value))
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheHousingBenefitAcademyDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+            {
+                // arrange
+                var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var housingBenefitAcademyFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>() {
+                        new string [] { "header 1", "header 2", "header 3" },
+                        new string [] { "0001133", "LMW", "123.12" }
+                    };
+
+                _mockReportGateway
+                    .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
+                        It.IsAny<int>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadCsvFile(
+                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                        It.Is<string>(fn =>
+                            fn.Contains("HB_Academy") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                        ),
+                        It.Is<string>(id => id == housingBenefitAcademyFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedHousingBenefitAcademyCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var housingBenefitAcademyFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var spreadSheetData = new List<string[]>();
+
+                _mockReportGateway
+                    .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
+                        It.IsAny<int>()
+                    ))
+                    .ReturnsAsync(spreadSheetData);
+
+                _mockGoogleClientService
+                    .Setup(g => g.UploadCsvFile(
+                        It.IsAny<List<string[]>>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(true);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFile);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == housingBenefitAcademyFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("HB_Academy") &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+            #endregion
+            #region Itemised Transactions
+            [Fact]
+            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnoperatingBalancesByRentAccount()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenOperatingBalancesByRentAccountFolderIdIsNotFound()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Output folder not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockTransactionGateway.Verify(
+                    g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCCallsTheTransactionGWGetPRNTransactionsWithApproapriateParametersFromTheReportRequest()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockTransactionGateway.Verify(
+                    g => g.GetPRNTransactions(
+                        It.Is<GetPRNTransactionsDomain>(w =>
+                            w.RentGroup == unprocessedReport.RentGroup &&
+                            w.FinancialYear == unprocessedReport.ReportYear.Value &&
+                            w.StartWeekOrMonth == unprocessedReport.ReportStartWeekOrMonth.Value &&
+                            w.EndWeekOrMonth == unprocessedReport.ReportEndWeekOrMonth.Value
+                        )
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCUploadsTheOperatingBalancesByRentAccountDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+                var opBalTransactionData = RandomGen.CreateMany<PRNTransactionDomain>(quantity: 2);
+                var csvStream = CSVHelper.ToCSVStreamFile(opBalTransactionData); // this method is tested & therefore safe
+
+                _mockTransactionGateway
+                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                    .ReturnsAsync(opBalTransactionData);
+
+                var irrelevantFile = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(irrelevantFile);
+
+                // act
+                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.UploadFileOrThrow(
+                        It.Is<FileInMemory>(fim =>
+                            Encoding.UTF8.GetString(fim.DataStream.ToArray()) == Encoding.UTF8.GetString(csvStream.ToArray()) &&
+                            fim.Name.Contains("Operating_Balances_by_Rent_Account") &&
+                            fim.Name.Contains(unprocessedReport.RentGroup) &&
+                            fim.Name.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fim.Name.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                            fim.Name.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                            fim.Name.Contains(unprocessedReport.Id.ToString())
+                        ),
+                        It.Is<string>(id => id == operatingBalancesByRentAccountFolder.GoogleIdentifier)
+                    ),
+                    Times.Once
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCRetrievesTheUploadedOperatingBalancesByRentAccountCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var opBalTransactions = new List<PRNTransactionDomain>();
+
+                _mockTransactionGateway
+                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                    .ReturnsAsync(opBalTransactions);
+
+                var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFileRepresentation);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Operating_Balances_by_Rent_Account") &&
+                            fn.Contains(unprocessedReport.RentGroup) &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.AtLeastOnce
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFileRepresentation.Id}"),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Once
+                );
+
+                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+                stepResponse.Should().NotBeNull();
+                stepResponse.Continue.Should().BeTrue();
+                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+            }
+
+            [Fact]
+            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedOperatingBalancesByRentAccountFileIsNotFoundBeforeTheCutoffCheckingTime()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var opBalTransactions = new List<PRNTransactionDomain>();
+
+                _mockTransactionGateway
+                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                    .ReturnsAsync(opBalTransactions);
+
+                GD.File uploadedCSVFileRepresentation = null;
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(uploadedCSVFileRepresentation);
+
+                // act
+                Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                await generateAReportCall.Should().NotThrowAsync().ConfigureAwait(false);
+
+                // assert
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.Is<string>(l => l == "Uploaded report file not found"),
+                        It.Is<bool>(s => s == false)
+                    ),
+                    Times.Once
+                );
+
+                _mockBatchReportGateway.Verify(
+                    g => g.SetStatusAsync(
+                        It.Is<int>(id => id == unprocessedReport.Id),
+                        It.IsAny<string>(),
+                        It.Is<bool>(isSuccess => isSuccess == true)
+                    ),
+                    Times.Never
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var opBalTransactions = new List<PRNTransactionDomain>();
+
+                _mockTransactionGateway
+                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                    .ReturnsAsync(opBalTransactions);
+
+                // var uploadedCSVFile = RandomGen.Create<GD.File>();
+                // var secondsUntilFileAvailable = 2;
+                // int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
+                // var fileAvailabilityTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+                //
+                // _mockGoogleClientService
+                //     .Setup(g => g.GetFileByNameInDriveAsync(
+                //         It.IsAny<string>(),
+                //         It.IsAny<string>()
+                //     ))
+                //     .ReturnsAsync(() =>
+                //     {
+                //         return DateTime.Now < fileAvailabilityTime ? null : uploadedCSVFile;
+                //     });
+                var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
+                var secondsUntilFileAvailable = 3;
+                int expectedNumberOfFileRetrievalAttempts = 600 / _retryInterval;
+                var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .ReturnsAsync(() => DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFileRepresentation);
+
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Operating_Balances_by_Rent_Account") &&
+                            fn.Contains(unprocessedReport.RentGroup) &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.Exactly(expectedNumberOfFileRetrievalAttempts)
+                );
+            }
+
+            [Fact]
+            public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
+            {
+                // arrange
+                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+                var unprocessedReport = RandomGen
+                    .Build<BatchReportDomain>()
+                    .With(r => r.ReportName, requestedReportLabel)
+                    .CreateCustom();
+
+                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+                var operatingBalancesByRentAccountFolder = RandomGen
+                    .Build<GoogleFileSettingDomain>()
+                    .With(f => f.Label, requestedReportLabel)
+                    .CreateCustom();
+
+                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+                _mockGoogleFileSettingGateway
+                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                    .ReturnsAsync(googleFileSettingsFound);
+
+                var opBalTransactions = new List<PRNTransactionDomain>();
+
+                _mockTransactionGateway
+                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                    .ReturnsAsync(opBalTransactions);
+
+                var uploadedCSVFile = RandomGen.Create<GD.File>();
+                int cutOffForNumberOfAttempts = 30;
+                DateTime? firstAttempt = null;
+                DateTime lastAttempt = DateTime.MinValue;
+                GD.File fileReturnedFromGDrive = null;
+
+                _mockGoogleClientService
+                    .Setup(g => g.GetFileByNameInDriveAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>()
+                    ))
+                    .Callback(() =>
+                    {
+                        firstAttempt ??= DateTime.Now;
+                        lastAttempt = DateTime.Now;
+                    })
+                    .ReturnsAsync(fileReturnedFromGDrive);
+
+                // act
+                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+                // assert
+                var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+
+                secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+
+                _mockGoogleClientService.Verify(
+                    g => g.GetFileByNameInDriveAsync(
+                        It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                        It.Is<string>(fn =>
+                            fn.Contains("Operating_Balances_by_Rent_Account") &&
+                            fn.Contains(unprocessedReport.RentGroup) &&
+                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                            fn.Contains(unprocessedReport.Id.ToString())
+                    )),
+                    Times.Exactly(cutOffForNumberOfAttempts)
+                );
+            }
+            #endregion
+        }
 }
-

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -1687,9 +1687,8 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(true);
 
             var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-            var secondsUntilFileAvailable = 3;
             int expectedNumberOfFileRetrievalAttempts = _waitDuration / _retryInterval;
-            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(3);
 
             _mockGoogleClientService
                 .Setup(g => g.GetFileByNameInDriveAsync(
@@ -3006,9 +3005,8 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(opBalTransactions);
 
             var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-            var secondsUntilFileAvailable = 3;
             int expectedNumberOfFileRetrievalAttempts = _waitDuration / _retryInterval;
-            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(4);
 
             _mockGoogleClientService
                 .Setup(g => g.GetFileByNameInDriveAsync(

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -407,9 +407,9 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
             var spreadSheetData = new List<string[]>() {
-                        new string [] { "header 1", "header 2", "header 3", "header 4" },
-                        new string [] { "0008425", "HRA", "520.36", "2020-08-08" }
-                    };
+                new string [] { "header 1", "header 2", "header 3", "header 4" },
+                new string [] { "0008425", "HRA", "520.36", "2020-08-08" }
+            };
 
             _mockReportGateway
                 .Setup(g => g.GetReportAccountBalanceAsync(

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -879,9 +879,9 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(googleFileSettingsFound);
 
             var spreadSheetData = new List<string[]>() {
-                        new string [] { "header 1", "header 2", "header 3", "header 4" },
-                        new string [] { "0001234", "TRA", "130.36", "2025-01-06" }
-                    };
+                new string [] { "header 1", "header 2", "header 3", "header 4" },
+                new string [] { "0001234", "TRA", "130.36", "2025-01-06" }
+            };
 
             _mockReportGateway
                 .Setup(g => g.GetChargesByYearAndRentGroupAsync(
@@ -941,9 +941,9 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(googleFileSettingsFound);
 
             var spreadSheetData = new List<string[]>() {
-                        new string [] { "header 1", "header 2", "header 3", "header 4" },
-                        new string [] { "0022455", "LSC", "7.88", "2023-04-22" }
-                    };
+                new string [] { "header 1", "header 2", "header 3", "header 4" },
+                new string [] { "0022455", "LSC", "7.88", "2023-04-22" }
+            };
 
             _mockReportGateway
                 .Setup(g => g.GetChargesByGroupTypeAsync(
@@ -1004,9 +1004,9 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .ReturnsAsync(googleFileSettingsFound);
 
             var spreadSheetData = new List<string[]>() {
-                        new string [] { "header 1", "header 2", "header 3", "header 4" },
-                        new string [] { "0004567", "LMW", "70.11", "2015-02-14" }
-                    };
+                new string [] { "header 1", "header 2", "header 3", "header 4" },
+                new string [] { "0004567", "LMW", "70.11", "2015-02-14" }
+            };
 
             _mockReportGateway
                 .Setup(g => g.GetChargesByYearAsync(

--- a/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/GenerateReportUseCaseTests.cs
@@ -12,3122 +12,3120 @@ using Moq;
 using Xunit;
 using HousingFinanceInterimApi.V1.Domain.ArgumentWrappers;
 using HousingFinanceInterimApi.V1.Helpers;
-using FluentAssertions.Common;
 using System.Text;
-using HousingFinanceInterimApi.V1.Boundary.Response;
 
 namespace HousingFinanceInterimApi.Tests.V1.UseCase
 {
-        public class GenerateReportUseCaseTests
+    public class GenerateReportUseCaseTests
+    {
+        private readonly Mock<IBatchReportGateway> _mockBatchReportGateway;
+        private readonly Mock<IReportGateway> _mockReportGateway;
+        private readonly Mock<ITransactionGateway> _mockTransactionGateway;
+        private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
+        private readonly Mock<IGoogleClientService> _mockGoogleClientService;
+        private readonly int _waitDuration = 3000; // 3 seconds
+        private readonly int _retryInterval = 200; // 0.2 seconds
+        private readonly IGenerateReportUseCase _classUnderTest;
+
+        public GenerateReportUseCaseTests()
         {
-            private readonly Mock<IBatchReportGateway> _mockBatchReportGateway;
-            private readonly Mock<IReportGateway> _mockReportGateway;
-            private readonly Mock<ITransactionGateway> _mockTransactionGateway;
-            private readonly Mock<IGoogleFileSettingGateway> _mockGoogleFileSettingGateway;
-            private readonly Mock<IGoogleClientService> _mockGoogleClientService;
-            private readonly int _waitDuration = 3000; // 3 seconds
-            private readonly int _retryInterval = 200; // 0.2 seconds
-            private readonly IGenerateReportUseCase _classUnderTest;
+            _mockBatchReportGateway = new Mock<IBatchReportGateway>();
+            _mockReportGateway = new Mock<IReportGateway>();
+            _mockTransactionGateway = new();
+            _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
+            _mockGoogleClientService = new Mock<IGoogleClientService>();
 
-            public GenerateReportUseCaseTests()
-            {
-                _mockBatchReportGateway = new Mock<IBatchReportGateway>();
-                _mockReportGateway = new Mock<IReportGateway>();
-                _mockTransactionGateway = new();
-                _mockGoogleFileSettingGateway = new Mock<IGoogleFileSettingGateway>();
-                _mockGoogleClientService = new Mock<IGoogleClientService>();
+            Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
 
-                Environment.SetEnvironmentVariable("WAIT_DURATION", _waitDuration.ToString());
-
-                _classUnderTest = new GenerateReportUseCase(
-                        _mockBatchReportGateway.Object,
-                        _mockReportGateway.Object,
-                        _mockTransactionGateway.Object,
-                        _mockGoogleFileSettingGateway.Object,
-                        _mockGoogleClientService.Object,
-                        _waitDuration,
-                        _retryInterval
-                    );
-            }
-
-            #region Shared
-            [Fact]
-            public async Task GenerateReportUCChecksWhetherAnyUnprocessedReportRequestsExist()
-            {
-                // arrange
-                var unprocessedReports = new List<BatchReportDomain>();
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(g => g.ListPendingAsync(), Times.Once);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenThereAreNoReportRequestsToProcess()
-            {
-                // arrange
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-                var unprocessedReports = new List<BatchReportDomain>();
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeFalse();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenTheRequestedReportNameFoundIsUnknown()
-            {
-                // arrange
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-                var unknownTypeUnprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, "Pepsi > CocaCola")
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unknownTypeUnprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCStartsGeneratingTheEarliestRequestedReportInTheQueue()
-            {
-                // arrange
-                var expectedearliestReportLabel = "ReportItemisedTransactions";
-
-                var earliestRequestedUnprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, expectedearliestReportLabel)
-                    .With(r => r.StartTime, DateTime.Now.AddMinutes(-20))
-                    .CreateCustom();
-
-                var lastRequestedUnprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, "ReportCashSuspense")
-                    .With(r => r.StartTime, DateTime.Now)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { lastRequestedUnprocessedReport, earliestRequestedUnprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var accountBalanceFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, expectedearliestReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == expectedearliestReportLabel)), Times.Once);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCThrowsAnExceptionWheneverOneIsRaisedWithinIt()
-            {
-                // arrange
-                var message = "The premise of the argument is incorrect.";
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ThrowsAsync(new ArgumentException(message));
-
-                // act
-                Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message).ConfigureAwait(false);
-            }
-            #endregion
-
-            #region Account Balance
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnAccountBalance()
-            {
-                // arrange
-                var requestedReportLabel = "ReportAccountBalanceByDate";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var accountBalanceFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenAccountBalanceFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportAccountBalanceByDate";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
+            _classUnderTest = new GenerateReportUseCase(
+                    _mockBatchReportGateway.Object,
+                    _mockReportGateway.Object,
+                    _mockTransactionGateway.Object,
+                    _mockGoogleFileSettingGateway.Object,
+                    _mockGoogleClientService.Object,
+                    _waitDuration,
+                    _retryInterval
                 );
+        }
 
-                _mockReportGateway.Verify(
-                    g => g.GetReportAccountBalanceAsync(
-                        It.IsAny<DateTime>(),
-                        It.IsAny<string>()
+        #region Shared
+        [Fact]
+        public async Task GenerateReportUCChecksWhetherAnyUnprocessedReportRequestsExist()
+        {
+            // arrange
+            var unprocessedReports = new List<BatchReportDomain>();
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(g => g.ListPendingAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenThereAreNoReportRequestsToProcess()
+        {
+            // arrange
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+            var unprocessedReports = new List<BatchReportDomain>();
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeFalse();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCTerminatesExecutionAndReturnsApproapriateResponseWhenTheRequestedReportNameFoundIsUnknown()
+        {
+            // arrange
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+            var unknownTypeUnprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, "Pepsi > CocaCola")
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unknownTypeUnprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.IsAny<string>()), Times.Never);
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCStartsGeneratingTheEarliestRequestedReportInTheQueue()
+        {
+            // arrange
+            var expectedearliestReportLabel = "ReportItemisedTransactions";
+
+            var earliestRequestedUnprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, expectedearliestReportLabel)
+                .With(r => r.StartTime, DateTime.Now.AddMinutes(-20))
+                .CreateCustom();
+
+            var lastRequestedUnprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, "ReportCashSuspense")
+                .With(r => r.StartTime, DateTime.Now)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { lastRequestedUnprocessedReport, earliestRequestedUnprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var accountBalanceFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, expectedearliestReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == expectedearliestReportLabel)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCThrowsAnExceptionWheneverOneIsRaisedWithinIt()
+        {
+            // arrange
+            var message = "The premise of the argument is incorrect.";
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ThrowsAsync(new ArgumentException(message));
+
+            // act
+            Func<Task> generateReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            await generateReportCall.Should().ThrowAsync<ArgumentException>().WithMessage(message).ConfigureAwait(false);
+        }
+        #endregion
+
+        #region Account Balance
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnAccountBalance()
+        {
+            // arrange
+            var requestedReportLabel = "ReportAccountBalanceByDate";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var accountBalanceFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenAccountBalanceFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportAccountBalanceByDate";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetReportAccountBalanceAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithDateTimeAndRentGroupFromTheReportRequestAlsoTheCreatedFileNameIsHasTrimmedRentGroup()
+        {
+            // arrange
+            var requestedRentGroup = "HRA";
+            var untrimmedRentGroup = $"  {requestedRentGroup} ";
+            var requestedReportLabel = "ReportAccountBalanceByDate";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, untrimmedRentGroup)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var accountBalanceFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetReportAccountBalanceAsync(
+                    It.Is<DateTime>(d => d.Equals(unprocessedReport.ReportDate.Value)),
+                    It.Is<string>(r => r == untrimmedRentGroup) // Odd, but that's the current behaviour.
+                ),
+                Times.Once
+            );
+
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.Is<string>(fn =>
+                        !fn.Contains(untrimmedRentGroup) &&
+                        fn.Contains(requestedRentGroup)
                     ),
-                    Times.Never
-                );
-            }
+                    It.IsAny<string>()
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithDateTimeAndRentGroupFromTheReportRequestAlsoTheCreatedFileNameIsHasTrimmedRentGroup()
-            {
-                // arrange
-                var requestedRentGroup = "HRA";
-                var untrimmedRentGroup = $"  {requestedRentGroup} ";
-                var requestedReportLabel = "ReportAccountBalanceByDate";
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithRentGroupValueSetAsNullButTheUploadedFileNameContainsTheValueALLWhenRentGroupIsNotProvided()
+        {
+            // arrange
+            var requestedReportLabel = "ReportAccountBalanceByDate";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, untrimmedRentGroup)
-                    .CreateCustom();
+            string requestedRentGroup = null;
+            var allRentGroups = "ALL";
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, requestedRentGroup)
+                .CreateCustom();
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                var accountBalanceFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+            var accountBalanceFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetReportAccountBalanceAsync(
-                        It.Is<DateTime>(d => d.Equals(unprocessedReport.ReportDate.Value)),
-                        It.Is<string>(r => r == untrimmedRentGroup) // Odd, but that's the current behaviour.
-                    ),
-                    Times.Once
-                );
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.Is<string>(fn =>
-                            !fn.Contains(untrimmedRentGroup) &&
-                            fn.Contains(requestedRentGroup)
-                        ),
-                        It.IsAny<string>()
-                    ),
-                    Times.Once
-                );
-            }
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetReportAccountBalanceAsync(
+                    It.IsAny<DateTime>(),
+                    It.Is<string>(r => r == requestedRentGroup)
+                ),
+                Times.Once
+            );
 
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetReportAccountBalanceWithRentGroupValueSetAsNullButTheUploadedFileNameContainsTheValueALLWhenRentGroupIsNotProvided()
-            {
-                // arrange
-                var requestedReportLabel = "ReportAccountBalanceByDate";
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.Is<string>(fn => fn.Contains(allRentGroups)),
+                    It.IsAny<string>()
+                ),
+                Times.Once
+            );
+        }
 
-                string requestedRentGroup = null;
-                var allRentGroups = "ALL";
+        [Fact]
+        public async Task GenerateReportUCUploadsTheAccountBalanceDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+        {
+            // arrange
+            var requestedReportLabel = "ReportAccountBalanceByDate";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, requestedRentGroup)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var accountBalanceFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var accountBalanceFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetReportAccountBalanceAsync(
-                        It.IsAny<DateTime>(),
-                        It.Is<string>(r => r == requestedRentGroup)
-                    ),
-                    Times.Once
-                );
-
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.Is<string>(fn => fn.Contains(allRentGroups)),
-                        It.IsAny<string>()
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCUploadsTheAccountBalanceDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-            {
-                // arrange
-                var requestedReportLabel = "ReportAccountBalanceByDate";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var accountBalanceFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>() {
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3", "header 4" },
                         new string [] { "0008425", "HRA", "520.36", "2020-08-08" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetReportAccountBalanceAsync(
-                        It.IsAny<DateTime>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetReportAccountBalanceAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn => fn.Contains("Account_Balance")),
-                        It.Is<string>(id => id == accountBalanceFolder.GoogleIdentifier)
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn => fn.Contains("Account_Balance")),
+                    It.Is<string>(id => id == accountBalanceFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedAccountBalanceCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportAccountBalanceByDate";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var accountBalanceFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetReportAccountBalanceAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == accountBalanceFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Account_Balance") &&
+                        fn.Contains(unprocessedReport.RentGroup) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+        #endregion
+
+        #region Charges
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsCharges()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenChargesFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAndRentGroupAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetChargesByGroupTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAsync(
+                    It.IsAny<int>()
+                ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetChargesByYearAndRentGroupWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheRentGroupIsNonEmpty()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAndRentGroupAsync(
+                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                    It.Is<string>(r => r == unprocessedReport.RentGroup)
+                ),
+                Times.Once
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetChargesByGroupTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAsync(
+                    It.IsAny<int>()
+                ),
+                Times.Never
+            );
+
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.Is<string>(fn =>
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.RentGroup) &&
+                        !fn.Contains(unprocessedReport.Group)
                     ),
-                    Times.Once
-                );
-            }
+                    It.IsAny<string>()
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedAccountBalanceCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportAccountBalanceByDate";
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetChargesByGroupTypeWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheGroupIsNonEmptyButTheRentGroupIsEmpty()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, null as string)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var accountBalanceFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { accountBalanceFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockReportGateway
-                    .Setup(g => g.GetReportAccountBalanceAsync(
-                        It.IsAny<DateTime>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAndRentGroupAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
+            _mockReportGateway.Verify(
+                g => g.GetChargesByGroupTypeAsync(
+                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                    It.Is<string>(r => r == unprocessedReport.Group)
+                ),
+                Times.Once
+            );
 
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAsync(
+                    It.IsAny<int>()
+                ),
+                Times.Never
+            );
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == accountBalanceFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Account_Balance") &&
-                            fn.Contains(unprocessedReport.RentGroup) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.Is<string>(fn =>
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Group)
                     ),
-                    Times.Once
-                );
+                    It.IsAny<string>()
+                ),
+                Times.Once
+            );
+        }
 
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetChargesByYearWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenBothTheGroupAndTheRentGroupAreEmpty()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
 
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-            #endregion
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, null as string)
+                .With(r => r.Group, null as string)
+                .CreateCustom();
 
-            #region Charges
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsCharges()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAndRentGroupAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            _mockReportGateway.Verify(
+                g => g.GetChargesByGroupTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
 
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
+            _mockReportGateway.Verify(
+                g => g.GetChargesByYearAsync(
+                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value))
+                ),
+                Times.Once
+            );
 
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenChargesFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.Is<string>(fn =>
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString())
                     ),
-                    Times.Once
-                );
+                    It.IsAny<string>()
+                ),
+                Times.Once
+            );
+        }
 
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAndRentGroupAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
+        [Fact]
+        public async Task GenerateReportUCUploadsTheChargesByYearAndRentGroupDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
 
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByGroupTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAsync(
-                        It.IsAny<int>()
-                    ),
-                    Times.Never
-                );
-            }
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetChargesByYearAndRentGroupWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheRentGroupIsNonEmpty()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAndRentGroupAsync(
-                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                        It.Is<string>(r => r == unprocessedReport.RentGroup)
-                    ),
-                    Times.Once
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByGroupTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAsync(
-                        It.IsAny<int>()
-                    ),
-                    Times.Never
-                );
-
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.Is<string>(fn =>
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.RentGroup) &&
-                            !fn.Contains(unprocessedReport.Group)
-                        ),
-                        It.IsAny<string>()
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetChargesByGroupTypeWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenTheGroupIsNonEmptyButTheRentGroupIsEmpty()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, null as string)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAndRentGroupAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByGroupTypeAsync(
-                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                        It.Is<string>(r => r == unprocessedReport.Group)
-                    ),
-                    Times.Once
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAsync(
-                        It.IsAny<int>()
-                    ),
-                    Times.Never
-                );
-
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.Is<string>(fn =>
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Group)
-                        ),
-                        It.IsAny<string>()
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetChargesByYearWithApproapriateParametersAndFileNameShouldContainThoseParamertersWhenBothTheGroupAndTheRentGroupAreEmpty()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, null as string)
-                    .With(r => r.Group, null as string)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAndRentGroupAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByGroupTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetChargesByYearAsync(
-                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value))
-                    ),
-                    Times.Once
-                );
-
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.Is<string>(fn =>
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString())
-                        ),
-                        It.IsAny<string>()
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCUploadsTheChargesByYearAndRentGroupDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>() {
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3", "header 4" },
                         new string [] { "0001234", "TRA", "130.36", "2025-01-06" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetChargesByYearAndRentGroupAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetChargesByYearAndRentGroupAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn => fn.Contains("Charges")),
-                        It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-                    ),
-                    Times.Once
-                );
-            }
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn => fn.Contains("Charges")),
+                    It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCUploadsTheChargesByGroupTypeDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
+        [Fact]
+        public async Task GenerateReportUCUploadsTheChargesByGroupTypeDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, null as string)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, null as string)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>() {
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3", "header 4" },
                         new string [] { "0022455", "LSC", "7.88", "2023-04-22" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetChargesByGroupTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetChargesByGroupTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn => fn.Contains("Charges")),
-                        It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-                    ),
-                    Times.Once
-                );
-            }
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn => fn.Contains("Charges")),
+                    It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCUploadsTheChargesByYearDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
+        [Fact]
+        public async Task GenerateReportUCUploadsTheChargesByYearDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportType()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, null as string)
-                    .With(r => r.Group, null as string)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, null as string)
+                .With(r => r.Group, null as string)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>() {
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3", "header 4" },
                         new string [] { "0004567", "LMW", "70.11", "2015-02-14" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetChargesByYearAsync(
-                        It.IsAny<int>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn => fn.Contains("Charges")),
-                        It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedChargesByYearAndRentGroupCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetChargesByYearAndRentGroupAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Charges") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.RentGroup.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedChargesByGroupTypeCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, null as string)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetChargesByGroupTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Charges") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Group.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedChargesByYearCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCharges";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .With(r => r.RentGroup, null as string)
-                    .With(r => r.Group, null as string)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var chargesFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetChargesByYearAsync(
-                        It.IsAny<int>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                var expectedNextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Charges") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(expectedNextStepTime, 1500);
-            }
-            #endregion
-
-            #region Itemised Transactions
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnItemisedTransactions()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenItemisedTransactionFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetItemisedTransactionsByYearAndTransactionTypeWithApproapriateParametersFromTheReportRequest()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.Is<int>(y => y == unprocessedReport.ReportYear.Value),
-                        It.Is<string>(t => t == unprocessedReport.TransactionType)
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCUploadsTheItemisedTransactionsDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>() {
+            _mockReportGateway
+                .Setup(g => g.GetChargesByYearAsync(
+                    It.IsAny<int>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn => fn.Contains("Charges")),
+                    It.Is<string>(id => id == chargesFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedChargesByYearAndRentGroupCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetChargesByYearAndRentGroupAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Charges") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.RentGroup.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedChargesByGroupTypeCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, null as string)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetChargesByGroupTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Charges") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Group.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(_waitDuration), 1000);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedChargesByYearCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCharges";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .With(r => r.RentGroup, null as string)
+                .With(r => r.Group, null as string)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var chargesFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { chargesFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetChargesByYearAsync(
+                    It.IsAny<int>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            var expectedNextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == chargesFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Charges") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(expectedNextStepTime, 1500);
+        }
+        #endregion
+
+        #region Itemised Transactions
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnItemisedTransactions()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenItemisedTransactionFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetItemisedTransactionsByYearAndTransactionTypeWithApproapriateParametersFromTheReportRequest()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.Is<int>(y => y == unprocessedReport.ReportYear.Value),
+                    It.Is<string>(t => t == unprocessedReport.TransactionType)
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCUploadsTheItemisedTransactionsDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3" },
                         new string [] { "00088255", "LMW", "251.23" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn =>
-                            fn.Contains("Itemised_Transactions") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.TransactionType) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                        ),
-                        It.Is<string>(id => id == itemisedTransactionsFolder.GoogleIdentifier)
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn =>
+                        fn.Contains("Itemised_Transactions") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.TransactionType) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
                     ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedItemisedTransactionsCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Itemised_Transactions") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.TransactionType) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
-
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedItemisedTransactionsFileIsNotFoundBeforeTheCutoffCheckingTime()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                GD.File uploadedCSVFile = null;
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
-
-                // act
-                Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                await generateAReportCall.Should().NotThrowAsync();
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Uploaded report file not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.IsAny<string>(),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Never
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-                var secondsUntilFileAvailable = 2;
-                int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
-                var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(() => DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFile);
-
-
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                Assert.True(stepResponse.Continue);
-
-
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Itemised_Transactions") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.TransactionType) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.Exactly(expectedNumberOfFileRetrievalAttempts)
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
-            {
-                // arrange
-                var requestedReportLabel = "ReportItemisedTransactions";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var itemisedTransactionsFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-                int cutOffForNumberOfAttempts = 30;
-                DateTime? firstAttempt = null;
-                DateTime lastAttempt = DateTime.MinValue;
-                GD.File fileReturnedFromGDrive = null;
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .Callback(() =>
-                    {
-                        firstAttempt ??= DateTime.Now;
-                        lastAttempt = DateTime.Now;
-                    })
-                    .ReturnsAsync(fileReturnedFromGDrive);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
-
-                secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
-
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Itemised_Transactions") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.TransactionType) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.Exactly(cutOffForNumberOfAttempts)
-                );
-            }
-            #endregion
-
-            #region Cash Suspense
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashSuspense()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashSuspense";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var cashSuspenseFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashSuspenseFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashSuspense";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
-
-                _mockReportGateway.Verify(
-                    g => g.GetCashSuspenseAccountByYearAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ),
-                    Times.Never
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetCashSuspenseAccountByYearWithApproapriateParametersFromTheReportRequest()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashSuspense";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var cashSuspenseFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetCashSuspenseAccountByYearAsync(
-                        It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
-                        It.Is<string>(r => r == unprocessedReport.Group)
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCUploadsTheCashSuspenseDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashSuspense";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var cashSuspenseFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>() {
+                    It.Is<string>(id => id == itemisedTransactionsFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedItemisedTransactionsCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Itemised_Transactions") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.TransactionType) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedItemisedTransactionsFileIsNotFoundBeforeTheCutoffCheckingTime()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            GD.File uploadedCSVFile = null;
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            await generateAReportCall.Should().NotThrowAsync();
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Uploaded report file not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.IsAny<string>(),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+            var secondsUntilFileAvailable = 2;
+            int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
+            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(() => DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFile);
+
+
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            Assert.True(stepResponse.Continue);
+
+
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Itemised_Transactions") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.TransactionType) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.Exactly(expectedNumberOfFileRetrievalAttempts)
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedItemisedTransactionsCSVFileIdAfterSpending30SecondsDoingIt()
+        {
+            // arrange
+            var requestedReportLabel = "ReportItemisedTransactions";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var itemisedTransactionsFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { itemisedTransactionsFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetItemisedTransactionsByYearAndTransactionTypeAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+            int cutOffForNumberOfAttempts = 30;
+            DateTime? firstAttempt = null;
+            DateTime lastAttempt = DateTime.MinValue;
+            GD.File fileReturnedFromGDrive = null;
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .Callback(() =>
+                {
+                    firstAttempt ??= DateTime.Now;
+                    lastAttempt = DateTime.Now;
+                })
+                .ReturnsAsync(fileReturnedFromGDrive);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+
+            secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == itemisedTransactionsFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Itemised_Transactions") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.TransactionType) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.Exactly(cutOffForNumberOfAttempts)
+            );
+        }
+        #endregion
+
+        #region Cash Suspense
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashSuspense()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashSuspense";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var cashSuspenseFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashSuspenseFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashSuspense";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockReportGateway.Verify(
+                g => g.GetCashSuspenseAccountByYearAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetCashSuspenseAccountByYearWithApproapriateParametersFromTheReportRequest()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashSuspense";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var cashSuspenseFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetCashSuspenseAccountByYearAsync(
+                    It.Is<int>(d => d.Equals(unprocessedReport.ReportYear.Value)),
+                    It.Is<string>(r => r == unprocessedReport.Group)
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCUploadsTheCashSuspenseDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashSuspense";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var cashSuspenseFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3" },
                         new string [] { "0000112", "TRA", "0.01" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetCashSuspenseAccountByYearAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetCashSuspenseAccountByYearAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn =>
-                            fn.Contains("Cash_Suspense") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Group) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                        ),
-                        It.Is<string>(id => id == cashSuspenseFolder.GoogleIdentifier)
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn =>
+                        fn.Contains("Cash_Suspense") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Group) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
                     ),
-                    Times.Once
-                );
-            }
+                    It.Is<string>(id => id == cashSuspenseFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedCashSuspenseCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashSuspense";
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedCashSuspenseCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashSuspense";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var cashSuspenseFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var cashSuspenseFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashSuspenseFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>();
+            var spreadSheetData = new List<string[]>();
 
-                _mockReportGateway
-                    .Setup(g => g.GetCashSuspenseAccountByYearAsync(
-                        It.IsAny<int>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetCashSuspenseAccountByYearAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
 
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
 
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == cashSuspenseFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Cash_Suspense") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Group) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == cashSuspenseFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Cash_Suspense") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Group) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
 
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
 
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
 
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-            #endregion
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+        #endregion
 
-            #region Cash Import
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashImport()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashImport";
+        #region Cash Import
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsACashImport()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashImport";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var cashImportFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var cashImportFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
 
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashImportFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashImport";
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenCashImportFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashImport";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
 
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
 
-                _mockReportGateway.Verify(
-                    g => g.GetCashImportByDateAsync(
-                        It.IsAny<DateTime>(),
-                        It.IsAny<DateTime>()
-                    ),
-                    Times.Never
-                );
-            }
+            _mockReportGateway.Verify(
+                g => g.GetCashImportByDateAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime>()
+                ),
+                Times.Never
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetCashImportByDateWithApproapriateParametersFromTheReportRequest()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashImport";
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetCashImportByDateWithApproapriateParametersFromTheReportRequest()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashImport";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var cashImportFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var cashImportFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetCashImportByDateAsync(
-                        It.Is<DateTime>(s => s.Equals(unprocessedReport.ReportStartDate.Value)),
-                        It.Is<DateTime>(e => e.Equals(unprocessedReport.ReportEndDate.Value))
-                    ),
-                    Times.Once
-                );
-            }
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetCashImportByDateAsync(
+                    It.Is<DateTime>(s => s.Equals(unprocessedReport.ReportStartDate.Value)),
+                    It.Is<DateTime>(e => e.Equals(unprocessedReport.ReportEndDate.Value))
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCUploadsTheCashImportDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashImport";
+        [Fact]
+        public async Task GenerateReportUCUploadsTheCashImportDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashImport";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var cashImportFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var cashImportFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>() {
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3" },
                         new string [] { "0000223", "LSC", "3.01" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetCashImportByDateAsync(
-                        It.IsAny<DateTime>(),
-                        It.IsAny<DateTime>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetCashImportByDateAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn =>
-                            fn.Contains("Cash_Import") &&
-                            fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
-                            fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                        ),
-                        It.Is<string>(id => id == cashImportFolder.GoogleIdentifier)
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn =>
+                        fn.Contains("Cash_Import") &&
+                        fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
+                        fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
                     ),
-                    Times.Once
-                );
-            }
+                    It.Is<string>(id => id == cashImportFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedCashImportCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportCashImport";
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedCashImportCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportCashImport";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var cashImportFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var cashImportFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { cashImportFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>();
+            var spreadSheetData = new List<string[]>();
 
-                _mockReportGateway
-                    .Setup(g => g.GetCashImportByDateAsync(
-                        It.IsAny<DateTime>(),
-                        It.IsAny<DateTime>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetCashImportByDateAsync(
+                    It.IsAny<DateTime>(),
+                    It.IsAny<DateTime>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
 
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
 
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == cashImportFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Cash_Import") &&
-                            fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
-                            fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == cashImportFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Cash_Import") &&
+                        fn.Contains(unprocessedReport.ReportStartDate.Value.ToString("ddMMyyyy")) &&
+                        fn.Contains(unprocessedReport.ReportEndDate.Value.ToString("ddMMyyyy")) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
 
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
 
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
 
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-            #endregion
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+        #endregion
 
-            #region Housing Benefit Academy
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAHousingBenefitAcademy()
-            {
-                // arrange
-                var requestedReportLabel = "ReportHousingBenefitAcademy";
+        #region Housing Benefit Academy
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAHousingBenefitAcademy()
+        {
+            // arrange
+            var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var housingBenefitAcademyFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var housingBenefitAcademyFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
 
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenHousingBenefitAcademyFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportHousingBenefitAcademy";
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenHousingBenefitAcademyFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
 
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
 
-                _mockReportGateway.Verify(
-                    g => g.GetHousingBenefitAcademyByYearAsync(
-                        It.IsAny<int>()
-                    ),
-                    Times.Never
-                );
-            }
+            _mockReportGateway.Verify(
+                g => g.GetHousingBenefitAcademyByYearAsync(
+                    It.IsAny<int>()
+                ),
+                Times.Never
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCCallsTheReportGWGetHousingBenefitAcademyByYearWithApproapriateParametersFromTheReportRequest()
-            {
-                // arrange
-                var requestedReportLabel = "ReportHousingBenefitAcademy";
+        [Fact]
+        public async Task GenerateReportUCCallsTheReportGWGetHousingBenefitAcademyByYearWithApproapriateParametersFromTheReportRequest()
+        {
+            // arrange
+            var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var housingBenefitAcademyFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var housingBenefitAcademyFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
 
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockReportGateway.Verify(
-                    g => g.GetHousingBenefitAcademyByYearAsync(
-                        It.Is<int>(s => s.Equals(unprocessedReport.ReportYear.Value))
-                    ),
-                    Times.Once
-                );
-            }
+            // assert
+            _mockReportGateway.Verify(
+                g => g.GetHousingBenefitAcademyByYearAsync(
+                    It.Is<int>(s => s.Equals(unprocessedReport.ReportYear.Value))
+                ),
+                Times.Once
+            );
+        }
 
-            [Fact]
-            public async Task GenerateReportUCUploadsTheHousingBenefitAcademyDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-            {
-                // arrange
-                var requestedReportLabel = "ReportHousingBenefitAcademy";
+        [Fact]
+        public async Task GenerateReportUCUploadsTheHousingBenefitAcademyDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+        {
+            // arrange
+            var requestedReportLabel = "ReportHousingBenefitAcademy";
 
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
 
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
 
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
 
-                var housingBenefitAcademyFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
+            var housingBenefitAcademyFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
 
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
 
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
 
-                var spreadSheetData = new List<string[]>() {
+            var spreadSheetData = new List<string[]>() {
                         new string [] { "header 1", "header 2", "header 3" },
                         new string [] { "0001133", "LMW", "123.12" }
                     };
 
-                _mockReportGateway
-                    .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
-                        It.IsAny<int>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
+            _mockReportGateway
+                .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
+                    It.IsAny<int>()
+                ))
+                .ReturnsAsync(spreadSheetData);
 
-                var irrelevantFile = RandomGen.Create<GD.File>();
+            var irrelevantFile = RandomGen.Create<GD.File>();
 
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
 
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
 
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadCsvFile(
-                        It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
-                        It.Is<string>(fn =>
-                            fn.Contains("HB_Academy") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                        ),
-                        It.Is<string>(id => id == housingBenefitAcademyFolder.GoogleIdentifier)
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadCsvFile(
+                    It.Is<List<string[]>>(t => ReferenceEquals(t, spreadSheetData)),
+                    It.Is<string>(fn =>
+                        fn.Contains("HB_Academy") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
                     ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedHousingBenefitAcademyCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportHousingBenefitAcademy";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var housingBenefitAcademyFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var spreadSheetData = new List<string[]>();
-
-                _mockReportGateway
-                    .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
-                        It.IsAny<int>()
-                    ))
-                    .ReturnsAsync(spreadSheetData);
-
-                _mockGoogleClientService
-                    .Setup(g => g.UploadCsvFile(
-                        It.IsAny<List<string[]>>(),
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(true);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFile);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == housingBenefitAcademyFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("HB_Academy") &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
-
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-            #endregion
-            #region Itemised Transactions
-            [Fact]
-            public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnoperatingBalancesByRentAccount()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenOperatingBalancesByRentAccountFolderIdIsNotFound()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Output folder not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
-
-                _mockTransactionGateway.Verify(
-                    g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()),
-                    Times.Never
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCCallsTheTransactionGWGetPRNTransactionsWithApproapriateParametersFromTheReportRequest()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockTransactionGateway.Verify(
-                    g => g.GetPRNTransactions(
-                        It.Is<GetPRNTransactionsDomain>(w =>
-                            w.RentGroup == unprocessedReport.RentGroup &&
-                            w.FinancialYear == unprocessedReport.ReportYear.Value &&
-                            w.StartWeekOrMonth == unprocessedReport.ReportStartWeekOrMonth.Value &&
-                            w.EndWeekOrMonth == unprocessedReport.ReportEndWeekOrMonth.Value
-                        )
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCUploadsTheOperatingBalancesByRentAccountDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
-
-                var opBalTransactionData = RandomGen.CreateMany<PRNTransactionDomain>(quantity: 2);
-                var csvStream = CSVHelper.ToCSVStreamFile(opBalTransactionData); // this method is tested & therefore safe
-
-                _mockTransactionGateway
-                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                    .ReturnsAsync(opBalTransactionData);
-
-                var irrelevantFile = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(irrelevantFile);
-
-                // act
-                await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.UploadFileOrThrow(
-                        It.Is<FileInMemory>(fim =>
-                            Encoding.UTF8.GetString(fim.DataStream.ToArray()) == Encoding.UTF8.GetString(csvStream.ToArray()) &&
-                            fim.Name.Contains("Operating_Balances_by_Rent_Account") &&
-                            fim.Name.Contains(unprocessedReport.RentGroup) &&
-                            fim.Name.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fim.Name.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                            fim.Name.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                            fim.Name.Contains(unprocessedReport.Id.ToString())
-                        ),
-                        It.Is<string>(id => id == operatingBalancesByRentAccountFolder.GoogleIdentifier)
-                    ),
-                    Times.Once
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCRetrievesTheUploadedOperatingBalancesByRentAccountCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var opBalTransactions = new List<PRNTransactionDomain>();
-
-                _mockTransactionGateway
-                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                    .ReturnsAsync(opBalTransactions);
-
-                var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFileRepresentation);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Operating_Balances_by_Rent_Account") &&
-                            fn.Contains(unprocessedReport.RentGroup) &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.AtLeastOnce
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFileRepresentation.Id}"),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Once
-                );
-
-                var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
-
-                stepResponse.Should().NotBeNull();
-                stepResponse.Continue.Should().BeTrue();
-                stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
-            }
-
-            [Fact]
-            public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedOperatingBalancesByRentAccountFileIsNotFoundBeforeTheCutoffCheckingTime()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var opBalTransactions = new List<PRNTransactionDomain>();
-
-                _mockTransactionGateway
-                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                    .ReturnsAsync(opBalTransactions);
-
-                GD.File uploadedCSVFileRepresentation = null;
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(uploadedCSVFileRepresentation);
-
-                // act
-                Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                await generateAReportCall.Should().NotThrowAsync().ConfigureAwait(false);
-
-                // assert
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.Is<string>(l => l == "Uploaded report file not found"),
-                        It.Is<bool>(s => s == false)
-                    ),
-                    Times.Once
-                );
-
-                _mockBatchReportGateway.Verify(
-                    g => g.SetStatusAsync(
-                        It.Is<int>(id => id == unprocessedReport.Id),
-                        It.IsAny<string>(),
-                        It.Is<bool>(isSuccess => isSuccess == true)
-                    ),
-                    Times.Never
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var opBalTransactions = new List<PRNTransactionDomain>();
-
-                _mockTransactionGateway
-                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                    .ReturnsAsync(opBalTransactions);
-
-                // var uploadedCSVFile = RandomGen.Create<GD.File>();
-                // var secondsUntilFileAvailable = 2;
-                // int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
-                // var fileAvailabilityTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
-                //
-                // _mockGoogleClientService
-                //     .Setup(g => g.GetFileByNameInDriveAsync(
-                //         It.IsAny<string>(),
-                //         It.IsAny<string>()
-                //     ))
-                //     .ReturnsAsync(() =>
-                //     {
-                //         return DateTime.Now < fileAvailabilityTime ? null : uploadedCSVFile;
-                //     });
-                var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
-                var secondsUntilFileAvailable = 3;
-                int expectedNumberOfFileRetrievalAttempts = 600 / _retryInterval;
-                var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .ReturnsAsync(() => DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFileRepresentation);
-
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Operating_Balances_by_Rent_Account") &&
-                            fn.Contains(unprocessedReport.RentGroup) &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.Exactly(expectedNumberOfFileRetrievalAttempts)
-                );
-            }
-
-            [Fact]
-            public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
-            {
-                // arrange
-                var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
-
-                var unprocessedReport = RandomGen
-                    .Build<BatchReportDomain>()
-                    .With(r => r.ReportName, requestedReportLabel)
-                    .CreateCustom();
-
-                var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
-
-                _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
-
-                var operatingBalancesByRentAccountFolder = RandomGen
-                    .Build<GoogleFileSettingDomain>()
-                    .With(f => f.Label, requestedReportLabel)
-                    .CreateCustom();
-
-                var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
-
-                _mockGoogleFileSettingGateway
-                    .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
-                    .ReturnsAsync(googleFileSettingsFound);
-
-                var opBalTransactions = new List<PRNTransactionDomain>();
-
-                _mockTransactionGateway
-                    .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
-                    .ReturnsAsync(opBalTransactions);
-
-                var uploadedCSVFile = RandomGen.Create<GD.File>();
-                int cutOffForNumberOfAttempts = 30;
-                DateTime? firstAttempt = null;
-                DateTime lastAttempt = DateTime.MinValue;
-                GD.File fileReturnedFromGDrive = null;
-
-                _mockGoogleClientService
-                    .Setup(g => g.GetFileByNameInDriveAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<string>()
-                    ))
-                    .Callback(() =>
-                    {
-                        firstAttempt ??= DateTime.Now;
-                        lastAttempt = DateTime.Now;
-                    })
-                    .ReturnsAsync(fileReturnedFromGDrive);
-
-                // act
-                var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
-
-                // assert
-                var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
-
-                secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
-
-                _mockGoogleClientService.Verify(
-                    g => g.GetFileByNameInDriveAsync(
-                        It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
-                        It.Is<string>(fn =>
-                            fn.Contains("Operating_Balances_by_Rent_Account") &&
-                            fn.Contains(unprocessedReport.RentGroup) &&
-                            fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
-                            fn.Contains(unprocessedReport.Id.ToString())
-                    )),
-                    Times.Exactly(cutOffForNumberOfAttempts)
-                );
-            }
-            #endregion
+                    It.Is<string>(id => id == housingBenefitAcademyFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
         }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedHousingBenefitAcademyCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportHousingBenefitAcademy";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var housingBenefitAcademyFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { housingBenefitAcademyFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var spreadSheetData = new List<string[]>();
+
+            _mockReportGateway
+                .Setup(g => g.GetHousingBenefitAcademyByYearAsync(
+                    It.IsAny<int>()
+                ))
+                .ReturnsAsync(spreadSheetData);
+
+            _mockGoogleClientService
+                .Setup(g => g.UploadCsvFile(
+                    It.IsAny<List<string[]>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(true);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFile);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == housingBenefitAcademyFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("HB_Academy") &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFile.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+        #endregion
+        #region Itemised Transactions
+        [Fact]
+        public async Task GenerateReportUCSearchesForAnApproapriateGoogleFileSettingWhenRequestedReportIsAnoperatingBalancesByRentAccount()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleFileSettingGateway.Verify(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenOperatingBalancesByRentAccountFolderIdIsNotFound()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>();
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel)))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Output folder not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockTransactionGateway.Verify(
+                g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCCallsTheTransactionGWGetPRNTransactionsWithApproapriateParametersFromTheReportRequest()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockTransactionGateway.Verify(
+                g => g.GetPRNTransactions(
+                    It.Is<GetPRNTransactionsDomain>(w =>
+                        w.RentGroup == unprocessedReport.RentGroup &&
+                        w.FinancialYear == unprocessedReport.ReportYear.Value &&
+                        w.StartWeekOrMonth == unprocessedReport.ReportStartWeekOrMonth.Value &&
+                        w.EndWeekOrMonth == unprocessedReport.ReportEndWeekOrMonth.Value
+                    )
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCUploadsTheOperatingBalancesByRentAccountDataRetrievedFromDabataseAsCSVIntoExpectedFolderUnderANameSpecifyingAReportTypeAndRequestParameters()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway.Setup(g => g.GetSettingsByLabel(It.Is<string>(l => l == requestedReportLabel))).ReturnsAsync(googleFileSettingsFound);
+
+            var opBalTransactionData = RandomGen.CreateMany<PRNTransactionDomain>(quantity: 2);
+            var csvStream = CSVHelper.ToCSVStreamFile(opBalTransactionData); // this method is tested & therefore safe
+
+            _mockTransactionGateway
+                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                .ReturnsAsync(opBalTransactionData);
+
+            var irrelevantFile = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(irrelevantFile);
+
+            // act
+            await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.UploadFileOrThrow(
+                    It.Is<FileInMemory>(fim =>
+                        Encoding.UTF8.GetString(fim.DataStream.ToArray()) == Encoding.UTF8.GetString(csvStream.ToArray()) &&
+                        fim.Name.Contains("Operating_Balances_by_Rent_Account") &&
+                        fim.Name.Contains(unprocessedReport.RentGroup) &&
+                        fim.Name.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fim.Name.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                        fim.Name.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                        fim.Name.Contains(unprocessedReport.Id.ToString())
+                    ),
+                    It.Is<string>(id => id == operatingBalancesByRentAccountFolder.GoogleIdentifier)
+                ),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCRetrievesTheUploadedOperatingBalancesByRentAccountCSVFileIdAndUpdatesTheReportRequestByAttachingAFileLinkToItAndSettingItSuccessThenTheUCReturnsCorrectStepResponse()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var opBalTransactions = new List<PRNTransactionDomain>();
+
+            _mockTransactionGateway
+                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                .ReturnsAsync(opBalTransactions);
+
+            var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFileRepresentation);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Operating_Balances_by_Rent_Account") &&
+                        fn.Contains(unprocessedReport.RentGroup) &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.AtLeastOnce
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(link => link == $"https://drive.google.com/file/d/{uploadedCSVFileRepresentation.Id}"),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Once
+            );
+
+            var nextStepTime = DateTime.Now.AddSeconds(_waitDuration);
+
+            stepResponse.Should().NotBeNull();
+            stepResponse.Continue.Should().BeTrue();
+            stepResponse.NextStepTime.Should().BeCloseTo(nextStepTime, precision: 1000);
+        }
+
+        [Fact]
+        public async Task GenerateReportUCMarksReportRequestAsFailureAndTerminatesExecutionWhenUploadedOperatingBalancesByRentAccountFileIsNotFoundBeforeTheCutoffCheckingTime()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var opBalTransactions = new List<PRNTransactionDomain>();
+
+            _mockTransactionGateway
+                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                .ReturnsAsync(opBalTransactions);
+
+            GD.File uploadedCSVFileRepresentation = null;
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(uploadedCSVFileRepresentation);
+
+            // act
+            Func<Task> generateAReportCall = async () => await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            await generateAReportCall.Should().NotThrowAsync().ConfigureAwait(false);
+
+            // assert
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.Is<string>(l => l == "Uploaded report file not found"),
+                    It.Is<bool>(s => s == false)
+                ),
+                Times.Once
+            );
+
+            _mockBatchReportGateway.Verify(
+                g => g.SetStatusAsync(
+                    It.Is<int>(id => id == unprocessedReport.Id),
+                    It.IsAny<string>(),
+                    It.Is<bool>(isSuccess => isSuccess == true)
+                ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdIn1SecondPeriodsSoLongItHasntSpent30SecondsDoingIt()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var opBalTransactions = new List<PRNTransactionDomain>();
+
+            _mockTransactionGateway
+                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                .ReturnsAsync(opBalTransactions);
+
+            // var uploadedCSVFile = RandomGen.Create<GD.File>();
+            // var secondsUntilFileAvailable = 2;
+            // int expectedNumberOfFileRetrievalAttempts = Math.Min(secondsUntilFileAvailable * 1000, _waitDuration) / _retryInterval;
+            // var fileAvailabilityTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+            //
+            // _mockGoogleClientService
+            //     .Setup(g => g.GetFileByNameInDriveAsync(
+            //         It.IsAny<string>(),
+            //         It.IsAny<string>()
+            //     ))
+            //     .ReturnsAsync(() =>
+            //     {
+            //         return DateTime.Now < fileAvailabilityTime ? null : uploadedCSVFile;
+            //     });
+            var uploadedCSVFileRepresentation = RandomGen.Create<GD.File>();
+            var secondsUntilFileAvailable = 3;
+            int expectedNumberOfFileRetrievalAttempts = 600 / _retryInterval;
+            var uploadedCSVBecomesAvailableAtTime = DateTime.Now.AddSeconds(secondsUntilFileAvailable);
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .ReturnsAsync(() => DateTime.Now < uploadedCSVBecomesAvailableAtTime ? null : uploadedCSVFileRepresentation);
+
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Operating_Balances_by_Rent_Account") &&
+                        fn.Contains(unprocessedReport.RentGroup) &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.Exactly(expectedNumberOfFileRetrievalAttempts)
+            );
+        }
+
+        [Fact]
+        public async Task GenerateReportUCStopsItsAttemptsToRetrieveTheUploadedOperatingBalancesByRentAccountCSVFileIdAfterSpending30SecondsDoingIt()
+        {
+            // arrange
+            var requestedReportLabel = "ReportOperatingBalancesByRentAccount";
+
+            var unprocessedReport = RandomGen
+                .Build<BatchReportDomain>()
+                .With(r => r.ReportName, requestedReportLabel)
+                .CreateCustom();
+
+            var unprocessedReports = new List<BatchReportDomain>() { unprocessedReport };
+
+            _mockBatchReportGateway.Setup(g => g.ListPendingAsync()).ReturnsAsync(unprocessedReports);
+
+            var operatingBalancesByRentAccountFolder = RandomGen
+                .Build<GoogleFileSettingDomain>()
+                .With(f => f.Label, requestedReportLabel)
+                .CreateCustom();
+
+            var googleFileSettingsFound = new List<GoogleFileSettingDomain>() { operatingBalancesByRentAccountFolder };
+
+            _mockGoogleFileSettingGateway
+                .Setup(g => g.GetSettingsByLabel(It.IsAny<string>()))
+                .ReturnsAsync(googleFileSettingsFound);
+
+            var opBalTransactions = new List<PRNTransactionDomain>();
+
+            _mockTransactionGateway
+                .Setup(g => g.GetPRNTransactions(It.IsAny<GetPRNTransactionsDomain>()))
+                .ReturnsAsync(opBalTransactions);
+
+            var uploadedCSVFile = RandomGen.Create<GD.File>();
+            int cutOffForNumberOfAttempts = 30;
+            DateTime? firstAttempt = null;
+            DateTime lastAttempt = DateTime.MinValue;
+            GD.File fileReturnedFromGDrive = null;
+
+            _mockGoogleClientService
+                .Setup(g => g.GetFileByNameInDriveAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .Callback(() =>
+                {
+                    firstAttempt ??= DateTime.Now;
+                    lastAttempt = DateTime.Now;
+                })
+                .ReturnsAsync(fileReturnedFromGDrive);
+
+            // act
+            var stepResponse = await _classUnderTest.ExecuteAsync().ConfigureAwait(false);
+
+            // assert
+            var secondsSpentInWaitForTheFile = (int) (lastAttempt - firstAttempt.Value).TotalSeconds + 1;
+
+            secondsSpentInWaitForTheFile.Should().Be(cutOffForNumberOfAttempts);
+
+            _mockGoogleClientService.Verify(
+                g => g.GetFileByNameInDriveAsync(
+                    It.Is<string>(fid => fid == operatingBalancesByRentAccountFolder.GoogleIdentifier),
+                    It.Is<string>(fn =>
+                        fn.Contains("Operating_Balances_by_Rent_Account") &&
+                        fn.Contains(unprocessedReport.RentGroup) &&
+                        fn.Contains(unprocessedReport.ReportYear.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.ReportStartWeekOrMonth.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.ReportEndWeekOrMonth.Value.ToString()) &&
+                        fn.Contains(unprocessedReport.Id.ToString())
+                )),
+                Times.Exactly(cutOffForNumberOfAttempts)
+            );
+        }
+        #endregion
+    }
 }

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -18,10 +18,6 @@ namespace HousingFinanceInterimApi.V1.UseCase
         private readonly IBatchReportGateway _batchReportGateway;
         private readonly IReportGateway _reportGateway;
         private readonly ITransactionGateway _transactionGateway;
-        //private readonly IReportAccountBalanceGateway _reportAccountBalanceGateway;
-        //private readonly IReportChargesGateway _reportChargesGateway;
-        //private readonly IReportCashImportGateway _reportCashImportGateway;
-        //private readonly IReportSuspenseAccountGateway _reportSuspenseAccountGateway;
         private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
         private readonly IGoogleClientService _googleClientService;
         private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
@@ -41,8 +37,8 @@ namespace HousingFinanceInterimApi.V1.UseCase
             ITransactionGateway transactionGateway,
             IGoogleFileSettingGateway googleFileSettingGateway,
             IGoogleClientService googleClientService,
-            int sleepDuration = 30_000,
-            int retryInterval = 200
+            int sleepDuration = 30_000, // ms
+            int retryInterval = 200 // ms
             )
         {
             _batchReportGateway = batchReportGateway;

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -25,8 +25,8 @@ public class GenerateReportUseCase : IGenerateReportUseCase
     private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
     private readonly IGoogleClientService _googleClientService;
     private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
-    private readonly int _sleepDuration;
-
+    private readonly int _sleepDuration; // ms
+    private readonly int _retryInterval; // ms
     private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
     private const string ReportChargesLabel = "ReportCharges";
     private const string ReportOperatingBalancesByRentAccount = "ReportOperatingBalancesByRentAccount";
@@ -41,7 +41,8 @@ public class GenerateReportUseCase : IGenerateReportUseCase
         ITransactionGateway transactionGateway,
         IGoogleFileSettingGateway googleFileSettingGateway,
         IGoogleClientService googleClientService,
-        int sleepDuration = 30_000
+        int sleepDuration = 30_000,
+        int retryInterval = 200
         )
     {
         _batchReportGateway = batchReportGateway;
@@ -50,6 +51,7 @@ public class GenerateReportUseCase : IGenerateReportUseCase
         _googleFileSettingGateway = googleFileSettingGateway;
         _googleClientService = googleClientService;
         _sleepDuration = sleepDuration;
+        _retryInterval = retryInterval;
     }
 
     public async Task<StepResponse> ExecuteAsync()
@@ -259,7 +261,7 @@ public class GenerateReportUseCase : IGenerateReportUseCase
 
         do
         {
-            System.Threading.Thread.Sleep(200);
+            System.Threading.Thread.Sleep(_retryInterval);
 
             file = await _googleClientService
                 .GetFileByNameInDriveAsync(itemisedTransactionFolderGFS.GoogleIdentifier, fileName)

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -11,368 +11,368 @@ using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;
 using HousingFinanceInterimApi.V1.Helpers;
 
-namespace HousingFinanceInterimApi.V1.UseCase
+namespace HousingFinanceInterimApi.V1.UseCase;
+
+public class GenerateReportUseCase : IGenerateReportUseCase
 {
-    public class GenerateReportUseCase : IGenerateReportUseCase
+    private readonly IBatchReportGateway _batchReportGateway;
+    private readonly IReportGateway _reportGateway;
+    private readonly ITransactionGateway _transactionGateway;
+    //private readonly IReportAccountBalanceGateway _reportAccountBalanceGateway;
+    //private readonly IReportChargesGateway _reportChargesGateway;
+    //private readonly IReportCashImportGateway _reportCashImportGateway;
+    //private readonly IReportSuspenseAccountGateway _reportSuspenseAccountGateway;
+    private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
+    private readonly IGoogleClientService _googleClientService;
+
+    private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
+    private readonly int _sleepDuration = 1000;
+
+    private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
+    private const string ReportChargesLabel = "ReportCharges";
+    private const string ReportOperatingBalancesByRentAccount = "ReportOperatingBalancesByRentAccount";
+    private const string ReportItemisedTransactionsLabel = "ReportItemisedTransactions";
+    private const string ReportCashSuspenseLabel = "ReportCashSuspense";
+    private const string ReportCashImportLabel = "ReportCashImport";
+    private const string ReportHousingBenefitAcademyLabel = "ReportHousingBenefitAcademy";
+
+    public GenerateReportUseCase(
+        IBatchReportGateway batchReportGateway,
+        IReportGateway reportGateway,
+        ITransactionGateway transactionGateway,
+        IGoogleFileSettingGateway googleFileSettingGateway,
+        IGoogleClientService googleClientService)
     {
-        private readonly IBatchReportGateway _batchReportGateway;
-        private readonly IReportGateway _reportGateway;
-        private readonly ITransactionGateway _transactionGateway;
-        //private readonly IReportAccountBalanceGateway _reportAccountBalanceGateway;
-        //private readonly IReportChargesGateway _reportChargesGateway;
-        //private readonly IReportCashImportGateway _reportCashImportGateway;
-        //private readonly IReportSuspenseAccountGateway _reportSuspenseAccountGateway;
-        private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
-        private readonly IGoogleClientService _googleClientService;
+        _batchReportGateway = batchReportGateway;
+        _reportGateway = reportGateway;
+        _transactionGateway = transactionGateway;
+        _googleFileSettingGateway = googleFileSettingGateway;
+        _googleClientService = googleClientService;
+    }
 
-        private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
-        private readonly int _sleepDuration = 30000;
+    public async Task<StepResponse> ExecuteAsync()
+    {
+        LoggingHandler.LogInfo($"Checking if exist report in the queue");
+        var batchReports = await _batchReportGateway.ListPendingAsync().ConfigureAwait(false);
 
-        private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
-        private const string ReportChargesLabel = "ReportCharges";
-        private const string ReportOperatingBalancesByRentAccount = "ReportOperatingBalancesByRentAccount";
-        private const string ReportItemisedTransactionsLabel = "ReportItemisedTransactions";
-        private const string ReportCashSuspenseLabel = "ReportCashSuspense";
-        private const string ReportCashImportLabel = "ReportCashImport";
-        private const string ReportHousingBenefitAcademyLabel = "ReportHousingBenefitAcademy";
+        if (!batchReports.Any())
+            return new StepResponse() { Continue = false, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
 
-        public GenerateReportUseCase(
-            IBatchReportGateway batchReportGateway,
-            IReportGateway reportGateway,
-            ITransactionGateway transactionGateway,
-            IGoogleFileSettingGateway googleFileSettingGateway,
-            IGoogleClientService googleClientService)
+        var batchReport = batchReports.OrderBy(x => x.StartTime).First();
+
+        switch (batchReport.ReportName)
         {
-            _batchReportGateway = batchReportGateway;
-            _reportGateway = reportGateway;
-            _transactionGateway = transactionGateway;
-            _googleFileSettingGateway = googleFileSettingGateway;
-            _googleClientService = googleClientService;
+            case ReportAccountBalanceByDateLabel:
+                await CreateBalanceReportByDate(batchReport).ConfigureAwait(false);
+                break;
+            case ReportChargesLabel:
+                await CreateChargesReport(batchReport).ConfigureAwait(false);
+                break;
+            case ReportOperatingBalancesByRentAccount:
+                await CreateOperatingBalancesByRentAccount(batchReport).ConfigureAwait(false);
+                break;
+            case ReportItemisedTransactionsLabel:
+                await CreateItemisedTransactionsReport(batchReport).ConfigureAwait(false);
+                break;
+            case ReportCashSuspenseLabel:
+                await CreateCashSuspenseReport(batchReport).ConfigureAwait(false);
+                break;
+            case ReportCashImportLabel:
+                await CreateCashImportReport(batchReport).ConfigureAwait(false);
+                break;
+            case ReportHousingBenefitAcademyLabel:
+                await CreateHousingBenefitAcademyReport(batchReport).ConfigureAwait(false);
+                break;
+            default:
+                LoggingHandler.LogInfo($"Report label not found");
+                break;
         }
 
-        public async Task<StepResponse> ExecuteAsync()
+        return new StepResponse() { Continue = true, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
+    }
+
+    private async Task<GoogleFileSettingDomain> GetGoogleFileSetting(string label)
+    {
+        LoggingHandler.LogInfo($"Getting Google file settings for '{label}' label");
+        var googleFileSettings = await _googleFileSettingGateway.GetSettingsByLabel(label).ConfigureAwait(false);
+        LoggingHandler.LogInfo($"{googleFileSettings.Count} google file settings found");
+
+        return googleFileSettings.FirstOrDefault();
+    }
+
+    private async Task CreateBalanceReportByDate(BatchReportDomain batchReport)
+    {
+        var rentgroup = string.IsNullOrEmpty(batchReport.RentGroup) ? "ALL" : batchReport.RentGroup.Trim();
+        var reportDate = batchReport.ReportDate.Value.ToString("yyyyMMdd");
+
+        var googleFileSetting = await GetGoogleFileSetting(ReportAccountBalanceByDateLabel).ConfigureAwait(false);
+        if (googleFileSetting == null)
         {
-            LoggingHandler.LogInfo($"Checking if exist report in the queue");
-            var batchReports = await _batchReportGateway.ListPendingAsync().ConfigureAwait(false);
-
-            if (!batchReports.Any())
-                return new StepResponse() { Continue = false, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
-
-            var batchReport = batchReports.OrderBy(x => x.StartTime).First();
-
-            switch (batchReport.ReportName)
-            {
-                case ReportAccountBalanceByDateLabel:
-                    await CreateBalanceReportByDate(batchReport).ConfigureAwait(false);
-                    break;
-                case ReportChargesLabel:
-                    await CreateChargesReport(batchReport).ConfigureAwait(false);
-                    break;
-                case ReportOperatingBalancesByRentAccount:
-                    await CreateOperatingBalancesByRentAccount(batchReport).ConfigureAwait(false);
-                    break;
-                case ReportItemisedTransactionsLabel:
-                    await CreateItemisedTransactionsReport(batchReport).ConfigureAwait(false);
-                    break;
-                case ReportCashSuspenseLabel:
-                    await CreateCashSuspenseReport(batchReport).ConfigureAwait(false);
-                    break;
-                case ReportCashImportLabel:
-                    await CreateCashImportReport(batchReport).ConfigureAwait(false);
-                    break;
-                case ReportHousingBenefitAcademyLabel:
-                    await CreateHousingBenefitAcademyReport(batchReport).ConfigureAwait(false);
-                    break;
-                default:
-                    LoggingHandler.LogInfo($"Report label not found");
-                    break;
-            }
-
-            return new StepResponse() { Continue = true, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task<GoogleFileSettingDomain> GetGoogleFileSetting(string label)
-        {
-            LoggingHandler.LogInfo($"Getting Google file settings for '{label}' label");
-            var googleFileSettings = await _googleFileSettingGateway.GetSettingsByLabel(label).ConfigureAwait(false);
-            LoggingHandler.LogInfo($"{googleFileSettings.Count} google file settings found");
+        var folder = await _googleClientService
+            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
 
-            return googleFileSettings.FirstOrDefault();
+        var fileName = $"Account_Balance_{rentgroup}_{reportDate}_{batchReport.Id}.csv";
+        var reportAccountBalances = (List<string[]>) await _reportGateway.GetReportAccountBalanceAsync(batchReport.ReportDate.Value, batchReport.RentGroup).ConfigureAwait(false);
+
+        await _googleClientService
+            .UploadCsvFile(reportAccountBalances, fileName, googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        System.Threading.Thread.Sleep(_sleepDuration);
+
+        var file = await _googleClientService
+            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+            .ConfigureAwait(false);
+
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+    }
+
+    private async Task CreateChargesReport(BatchReportDomain batchReport)
+    {
+        var googleFileSetting = await GetGoogleFileSetting(ReportChargesLabel).ConfigureAwait(false);
+        if (googleFileSetting == null)
+        {
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task CreateBalanceReportByDate(BatchReportDomain batchReport)
+        var folder = await _googleClientService
+            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        var fileName = "";
+        var reportCharges = new List<string[]>();
+
+        if (!string.IsNullOrEmpty(batchReport.RentGroup))
         {
-            var rentgroup = string.IsNullOrEmpty(batchReport.RentGroup) ? "ALL" : batchReport.RentGroup.Trim();
-            var reportDate = batchReport.ReportDate.Value.ToString("yyyyMMdd");
-
-            var googleFileSetting = await GetGoogleFileSetting(ReportAccountBalanceByDateLabel).ConfigureAwait(false);
-            if (googleFileSetting == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var folder = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            var fileName = $"Account_Balance_{rentgroup}_{reportDate}_{batchReport.Id}.csv";
-            var reportAccountBalances = (List<string[]>) await _reportGateway.GetReportAccountBalanceAsync(batchReport.ReportDate.Value, batchReport.RentGroup).ConfigureAwait(false);
-
-            await _googleClientService
-                .UploadCsvFile(reportAccountBalances, fileName, googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            System.Threading.Thread.Sleep(_sleepDuration);
-
-            var file = await _googleClientService
-                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-                .ConfigureAwait(false);
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+            fileName = $"Charges_{batchReport.RentGroup}_{batchReport.ReportYear}_{batchReport.Id}.csv";
+            reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAndRentGroupAsync(batchReport.ReportYear.Value, batchReport.RentGroup).ConfigureAwait(false);
+        }
+        else if (!string.IsNullOrEmpty(batchReport.Group))
+        {
+            fileName = $"Charges_{batchReport.Group}_{batchReport.ReportYear}_{batchReport.Id}.csv";
+            reportCharges = (List<string[]>) await _reportGateway.GetChargesByGroupTypeAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
+        }
+        else
+        {
+            fileName = $"Charges_{batchReport.ReportYear}_{batchReport.Id}.csv";
+            reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
         }
 
-        private async Task CreateChargesReport(BatchReportDomain batchReport)
+        await _googleClientService
+            .UploadCsvFile(reportCharges, fileName, googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        System.Threading.Thread.Sleep(_sleepDuration);
+
+        var file = await _googleClientService
+            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+            .ConfigureAwait(false);
+
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+    }
+
+    private async Task CreateOperatingBalancesByRentAccount(BatchReportDomain batchReport)
+    {
+        var opBalsByRentAccFolderGFS = await GetGoogleFileSetting(ReportOperatingBalancesByRentAccount).ConfigureAwait(false);
+        if (opBalsByRentAccFolderGFS == null)
         {
-            var googleFileSetting = await GetGoogleFileSetting(ReportChargesLabel).ConfigureAwait(false);
-            if (googleFileSetting == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var folder = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            var fileName = "";
-            var reportCharges = new List<string[]>();
-
-            if (!string.IsNullOrEmpty(batchReport.RentGroup))
-            {
-                fileName = $"Charges_{batchReport.RentGroup}_{batchReport.ReportYear}_{batchReport.Id}.csv";
-                reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAndRentGroupAsync(batchReport.ReportYear.Value, batchReport.RentGroup).ConfigureAwait(false);
-            }
-            else if (!string.IsNullOrEmpty(batchReport.Group))
-            {
-                fileName = $"Charges_{batchReport.Group}_{batchReport.ReportYear}_{batchReport.Id}.csv";
-                reportCharges = (List<string[]>) await _reportGateway.GetChargesByGroupTypeAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
-            }
-            else
-            {
-                fileName = $"Charges_{batchReport.ReportYear}_{batchReport.Id}.csv";
-                reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
-            }
-
-            await _googleClientService
-                .UploadCsvFile(reportCharges, fileName, googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            System.Threading.Thread.Sleep(_sleepDuration);
-
-            var file = await _googleClientService
-                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-                .ConfigureAwait(false);
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task CreateOperatingBalancesByRentAccount(BatchReportDomain batchReport)
+        var fileName = $"Operating_Balances_by_Rent_Account_{batchReport.RentGroup}" +
+            $"_y{batchReport.ReportYear}_s{batchReport.ReportStartWeekOrMonth}" +
+            $"_e{batchReport.ReportEndWeekOrMonth}_id{batchReport.Id}.csv";
+
+        var reportCharges = await _transactionGateway
+            .GetPRNTransactions(batchReport.ExtractPRNTransactionArgs())
+            .ConfigureAwait(false);
+
+        var csvFile = CSVHelper.ToCSVInMemoryFile(reportCharges, fileName);
+
+        await _googleClientService
+            .UploadFileOrThrow(csvFile, opBalsByRentAccFolderGFS.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        GD.File file = null;
+
+        var waitDurationInSeconds = _sleepDuration / 1000;
+        var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
+
+        do
         {
-            var opBalsByRentAccFolderGFS = await GetGoogleFileSetting(ReportOperatingBalancesByRentAccount).ConfigureAwait(false);
-            if (opBalsByRentAccFolderGFS == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
+            System.Threading.Thread.Sleep(1000);
 
-            var fileName = $"Operating_Balances_by_Rent_Account_{batchReport.RentGroup}" +
-                $"_y{batchReport.ReportYear}_s{batchReport.ReportStartWeekOrMonth}" +
-                $"_e{batchReport.ReportEndWeekOrMonth}_id{batchReport.Id}.csv";
-
-            var reportCharges = await _transactionGateway
-                .GetPRNTransactions(batchReport.ExtractPRNTransactionArgs())
+            file = await _googleClientService
+                .GetFileByNameInDriveAsync(opBalsByRentAccFolderGFS.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
+        }
+        while (file is null && DateTime.Now < cuttoffTime);
 
-            var csvFile = CSVHelper.ToCSVInMemoryFile(reportCharges, fileName);
-
-            await _googleClientService
-                .UploadFileOrThrow(csvFile, opBalsByRentAccFolderGFS.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            GD.File file = null;
-
-            var waitDurationInSeconds = _sleepDuration / 1000;
-            var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
-
-            do
-            {
-                System.Threading.Thread.Sleep(1000);
-
-                file = await _googleClientService
-                    .GetFileByNameInDriveAsync(opBalsByRentAccFolderGFS.GoogleIdentifier, fileName)
-                    .ConfigureAwait(false);
-            }
-            while (file is null && DateTime.Now < cuttoffTime);
-
-            if (file is null)
-            {
-                LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {opBalsByRentAccFolderGFS.GoogleIdentifier} directory.");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+        if (file is null)
+        {
+            LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {opBalsByRentAccFolderGFS.GoogleIdentifier} directory.");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task CreateItemisedTransactionsReport(BatchReportDomain batchReport)
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+    }
+
+    private async Task CreateItemisedTransactionsReport(BatchReportDomain batchReport)
+    {
+        var itemisedTransactionFolderGFS = await GetGoogleFileSetting(ReportItemisedTransactionsLabel).ConfigureAwait(false);
+        if (itemisedTransactionFolderGFS == null)
         {
-            var itemisedTransactionFolderGFS = await GetGoogleFileSetting(ReportItemisedTransactionsLabel).ConfigureAwait(false);
-            if (itemisedTransactionFolderGFS == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var fileName = $"Itemised_Transactions_{batchReport.TransactionType}_{batchReport.ReportYear}_{batchReport.Id}.csv";
-            var reportCharges = (List<string[]>) await _reportGateway
-                .GetItemisedTransactionsByYearAndTransactionTypeAsync(batchReport.ReportYear.Value, batchReport.TransactionType)
-                .ConfigureAwait(false);
-
-            await _googleClientService
-                .UploadCsvFile(reportCharges, fileName, itemisedTransactionFolderGFS.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            GD.File file = null;
-
-            var waitDurationInSeconds = _sleepDuration / 1000;
-            var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
-
-            do
-            {
-                System.Threading.Thread.Sleep(1000);
-
-                file = await _googleClientService
-                    .GetFileByNameInDriveAsync(itemisedTransactionFolderGFS.GoogleIdentifier, fileName)
-                    .ConfigureAwait(false);
-            }
-            while (file is null && DateTime.Now < cuttoffTime);
-
-            if (file is null)
-            {
-                LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {itemisedTransactionFolderGFS.GoogleIdentifier} directory.");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task CreateCashSuspenseReport(BatchReportDomain batchReport)
+        var fileName = $"Itemised_Transactions_{batchReport.TransactionType}_{batchReport.ReportYear}_{batchReport.Id}.csv";
+        var reportCharges = (List<string[]>) await _reportGateway
+            .GetItemisedTransactionsByYearAndTransactionTypeAsync(batchReport.ReportYear.Value, batchReport.TransactionType)
+            .ConfigureAwait(false);
+
+        await _googleClientService
+            .UploadCsvFile(reportCharges, fileName, itemisedTransactionFolderGFS.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        GD.File file = null;
+
+        var waitDurationInSeconds = _sleepDuration / 1000;
+        var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
+
+        do
         {
-            var googleFileSetting = await GetGoogleFileSetting(ReportCashSuspenseLabel).ConfigureAwait(false);
-            if (googleFileSetting == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
+            System.Threading.Thread.Sleep(1000);
 
-            var folder = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+            file = await _googleClientService
+                .GetFileByNameInDriveAsync(itemisedTransactionFolderGFS.GoogleIdentifier, fileName)
                 .ConfigureAwait(false);
+        }
+        while (file is null && DateTime.Now < cuttoffTime);
 
-            var reportSuspenseAccount = (List<string[]>) await _reportGateway
-               .GetCashSuspenseAccountByYearAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
-
-            var fileName = $"Cash_Suspense_{batchReport.Group}_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
-
-            await _googleClientService
-                .UploadCsvFile(reportSuspenseAccount, fileName, googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            System.Threading.Thread.Sleep(_sleepDuration);
-
-            var file = await _googleClientService
-                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-                .ConfigureAwait(false);
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+        if (file is null)
+        {
+            LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {itemisedTransactionFolderGFS.GoogleIdentifier} directory.");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task CreateCashImportReport(BatchReportDomain batchReport)
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+    }
+
+    private async Task CreateCashSuspenseReport(BatchReportDomain batchReport)
+    {
+        var googleFileSetting = await GetGoogleFileSetting(ReportCashSuspenseLabel).ConfigureAwait(false);
+        if (googleFileSetting == null)
         {
-            var googleFileSetting = await GetGoogleFileSetting(ReportCashImportLabel).ConfigureAwait(false);
-            if (googleFileSetting == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var folder = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            var reportCashImport = (List<string[]>) await _reportGateway
-                .GetCashImportByDateAsync(batchReport.ReportStartDate.Value, batchReport.ReportEndDate.Value).ConfigureAwait(false);
-
-            var fileName = $"Cash_Import_{batchReport.ReportStartDate.Value.ToString("ddMMyyyy")}_{batchReport.ReportEndDate.Value.ToString("ddMMyyyy")}_{batchReport.Id}.csv";
-
-            await _googleClientService
-                .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            System.Threading.Thread.Sleep(_sleepDuration);
-
-            var file = await _googleClientService
-                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-                .ConfigureAwait(false);
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
         }
 
-        private async Task CreateHousingBenefitAcademyReport(BatchReportDomain batchReport)
+        var folder = await _googleClientService
+            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        var reportSuspenseAccount = (List<string[]>) await _reportGateway
+           .GetCashSuspenseAccountByYearAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
+
+        var fileName = $"Cash_Suspense_{batchReport.Group}_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
+
+        await _googleClientService
+            .UploadCsvFile(reportSuspenseAccount, fileName, googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        System.Threading.Thread.Sleep(_sleepDuration);
+
+        var file = await _googleClientService
+            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+            .ConfigureAwait(false);
+
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+    }
+
+    private async Task CreateCashImportReport(BatchReportDomain batchReport)
+    {
+        var googleFileSetting = await GetGoogleFileSetting(ReportCashImportLabel).ConfigureAwait(false);
+        if (googleFileSetting == null)
         {
-            var googleFileSetting = await GetGoogleFileSetting(ReportHousingBenefitAcademyLabel).ConfigureAwait(false);
-            if (googleFileSetting == null)
-            {
-                LoggingHandler.LogInfo($"Output folder not found");
-                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-                return;
-            }
-
-            var folder = await _googleClientService
-                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            var reportCashImport = (List<string[]>) await _reportGateway
-                .GetHousingBenefitAcademyByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
-
-            var fileName = $"HB_Academy_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
-
-            await _googleClientService
-                .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
-                .ConfigureAwait(false);
-
-            System.Threading.Thread.Sleep(_sleepDuration);
-
-            var file = await _googleClientService
-                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-                .ConfigureAwait(false);
-
-            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
         }
+
+        var folder = await _googleClientService
+            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        var reportCashImport = (List<string[]>) await _reportGateway
+            .GetCashImportByDateAsync(batchReport.ReportStartDate.Value, batchReport.ReportEndDate.Value).ConfigureAwait(false);
+
+        var fileName = $"Cash_Import_{batchReport.ReportStartDate.Value.ToString("ddMMyyyy")}_{batchReport.ReportEndDate.Value.ToString("ddMMyyyy")}_{batchReport.Id}.csv";
+
+        await _googleClientService
+            .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        System.Threading.Thread.Sleep(_sleepDuration);
+
+        var file = await _googleClientService
+            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+            .ConfigureAwait(false);
+
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+    }
+
+    private async Task CreateHousingBenefitAcademyReport(BatchReportDomain batchReport)
+    {
+        var googleFileSetting = await GetGoogleFileSetting(ReportHousingBenefitAcademyLabel).ConfigureAwait(false);
+        if (googleFileSetting == null)
+        {
+            LoggingHandler.LogInfo($"Output folder not found");
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+            return;
+        }
+
+        var folder = await _googleClientService
+            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        var reportCashImport = (List<string[]>) await _reportGateway
+            .GetHousingBenefitAcademyByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
+
+        var fileName = $"HB_Academy_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
+
+        await _googleClientService
+            .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
+            .ConfigureAwait(false);
+
+        System.Threading.Thread.Sleep(_sleepDuration);
+
+        var file = await _googleClientService
+            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+            .ConfigureAwait(false);
+
+        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
     }
 }
+

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -254,7 +254,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
                 .UploadCsvFile(reportCharges, fileName, itemisedTransactionFolderGFS.GoogleIdentifier)
                 .ConfigureAwait(false);
 
-            GD.File file = null;
+            GD.File file;
 
             var waitDurationInSeconds = _sleepDuration / 1000;
             var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -39,7 +39,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
             IGoogleFileSettingGateway googleFileSettingGateway,
             IGoogleClientService googleClientService,
             int sleepDuration = 30_000, // ms
-            int retryInterval = 200 // ms
+            int retryInterval = 1000 // ms
             )
         {
             _batchReportGateway = batchReportGateway;

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using HousingFinanceInterimApi.V1.Domain;
 using HousingFinanceInterimApi.V1.Factories;
@@ -250,7 +251,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
                 .UploadCsvFile(reportCharges, fileName, itemisedTransactionFolderGFS.GoogleIdentifier)
                 .ConfigureAwait(false);
 
-            GD.File file;
+            GD.File file = null;
 
             var waitDurationInSeconds = _sleepDuration / 1000;
             var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -11,372 +11,371 @@ using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;
 using HousingFinanceInterimApi.V1.Helpers;
 
-namespace HousingFinanceInterimApi.V1.UseCase;
-
-public class GenerateReportUseCase : IGenerateReportUseCase
-{
-    private readonly IBatchReportGateway _batchReportGateway;
-    private readonly IReportGateway _reportGateway;
-    private readonly ITransactionGateway _transactionGateway;
-    //private readonly IReportAccountBalanceGateway _reportAccountBalanceGateway;
-    //private readonly IReportChargesGateway _reportChargesGateway;
-    //private readonly IReportCashImportGateway _reportCashImportGateway;
-    //private readonly IReportSuspenseAccountGateway _reportSuspenseAccountGateway;
-    private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
-    private readonly IGoogleClientService _googleClientService;
-    private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
-    private readonly int _sleepDuration; // ms
-    private readonly int _retryInterval; // ms
-    private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
-    private const string ReportChargesLabel = "ReportCharges";
-    private const string ReportOperatingBalancesByRentAccount = "ReportOperatingBalancesByRentAccount";
-    private const string ReportItemisedTransactionsLabel = "ReportItemisedTransactions";
-    private const string ReportCashSuspenseLabel = "ReportCashSuspense";
-    private const string ReportCashImportLabel = "ReportCashImport";
-    private const string ReportHousingBenefitAcademyLabel = "ReportHousingBenefitAcademy";
-
-    public GenerateReportUseCase(
-        IBatchReportGateway batchReportGateway,
-        IReportGateway reportGateway,
-        ITransactionGateway transactionGateway,
-        IGoogleFileSettingGateway googleFileSettingGateway,
-        IGoogleClientService googleClientService,
-        int sleepDuration = 30_000,
-        int retryInterval = 200
-        )
+namespace HousingFinanceInterimApi.V1.UseCase {
+    public class GenerateReportUseCase : IGenerateReportUseCase
     {
-        _batchReportGateway = batchReportGateway;
-        _reportGateway = reportGateway;
-        _transactionGateway = transactionGateway;
-        _googleFileSettingGateway = googleFileSettingGateway;
-        _googleClientService = googleClientService;
-        _sleepDuration = sleepDuration;
-        _retryInterval = retryInterval;
-    }
+        private readonly IBatchReportGateway _batchReportGateway;
+        private readonly IReportGateway _reportGateway;
+        private readonly ITransactionGateway _transactionGateway;
+        //private readonly IReportAccountBalanceGateway _reportAccountBalanceGateway;
+        //private readonly IReportChargesGateway _reportChargesGateway;
+        //private readonly IReportCashImportGateway _reportCashImportGateway;
+        //private readonly IReportSuspenseAccountGateway _reportSuspenseAccountGateway;
+        private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
+        private readonly IGoogleClientService _googleClientService;
+        private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
+        private readonly int _sleepDuration; // ms
+        private readonly int _retryInterval; // ms
+        private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
+        private const string ReportChargesLabel = "ReportCharges";
+        private const string ReportOperatingBalancesByRentAccount = "ReportOperatingBalancesByRentAccount";
+        private const string ReportItemisedTransactionsLabel = "ReportItemisedTransactions";
+        private const string ReportCashSuspenseLabel = "ReportCashSuspense";
+        private const string ReportCashImportLabel = "ReportCashImport";
+        private const string ReportHousingBenefitAcademyLabel = "ReportHousingBenefitAcademy";
 
-    public async Task<StepResponse> ExecuteAsync()
-    {
-        LoggingHandler.LogInfo($"Checking if exist report in the queue");
-        var batchReports = await _batchReportGateway.ListPendingAsync().ConfigureAwait(false);
-
-        if (!batchReports.Any())
-            return new StepResponse() { Continue = false, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
-
-        var batchReport = batchReports.OrderBy(x => x.StartTime).First();
-
-        switch (batchReport.ReportName)
+        public GenerateReportUseCase(
+            IBatchReportGateway batchReportGateway,
+            IReportGateway reportGateway,
+            ITransactionGateway transactionGateway,
+            IGoogleFileSettingGateway googleFileSettingGateway,
+            IGoogleClientService googleClientService,
+            int sleepDuration = 30_000,
+            int retryInterval = 200
+            )
         {
-            case ReportAccountBalanceByDateLabel:
-                await CreateBalanceReportByDate(batchReport).ConfigureAwait(false);
-                break;
-            case ReportChargesLabel:
-                await CreateChargesReport(batchReport).ConfigureAwait(false);
-                break;
-            case ReportOperatingBalancesByRentAccount:
-                await CreateOperatingBalancesByRentAccount(batchReport).ConfigureAwait(false);
-                break;
-            case ReportItemisedTransactionsLabel:
-                await CreateItemisedTransactionsReport(batchReport).ConfigureAwait(false);
-                break;
-            case ReportCashSuspenseLabel:
-                await CreateCashSuspenseReport(batchReport).ConfigureAwait(false);
-                break;
-            case ReportCashImportLabel:
-                await CreateCashImportReport(batchReport).ConfigureAwait(false);
-                break;
-            case ReportHousingBenefitAcademyLabel:
-                await CreateHousingBenefitAcademyReport(batchReport).ConfigureAwait(false);
-                break;
-            default:
-                LoggingHandler.LogInfo($"Report label not found");
-                break;
+            _batchReportGateway = batchReportGateway;
+            _reportGateway = reportGateway;
+            _transactionGateway = transactionGateway;
+            _googleFileSettingGateway = googleFileSettingGateway;
+            _googleClientService = googleClientService;
+            _sleepDuration = sleepDuration;
+            _retryInterval = retryInterval;
         }
 
-        return new StepResponse() { Continue = true, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
-    }
-
-    private async Task<GoogleFileSettingDomain> GetGoogleFileSetting(string label)
-    {
-        LoggingHandler.LogInfo($"Getting Google file settings for '{label}' label");
-        var googleFileSettings = await _googleFileSettingGateway.GetSettingsByLabel(label).ConfigureAwait(false);
-        LoggingHandler.LogInfo($"{googleFileSettings.Count} google file settings found");
-
-        return googleFileSettings.FirstOrDefault();
-    }
-
-    private async Task CreateBalanceReportByDate(BatchReportDomain batchReport)
-    {
-        var rentgroup = string.IsNullOrEmpty(batchReport.RentGroup) ? "ALL" : batchReport.RentGroup.Trim();
-        var reportDate = batchReport.ReportDate.Value.ToString("yyyyMMdd");
-
-        var googleFileSetting = await GetGoogleFileSetting(ReportAccountBalanceByDateLabel).ConfigureAwait(false);
-        if (googleFileSetting == null)
+        public async Task<StepResponse> ExecuteAsync()
         {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
+            LoggingHandler.LogInfo($"Checking if exist report in the queue");
+            var batchReports = await _batchReportGateway.ListPendingAsync().ConfigureAwait(false);
+
+            if (!batchReports.Any())
+                return new StepResponse() { Continue = false, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
+
+            var batchReport = batchReports.OrderBy(x => x.StartTime).First();
+
+            switch (batchReport.ReportName)
+            {
+                case ReportAccountBalanceByDateLabel:
+                    await CreateBalanceReportByDate(batchReport).ConfigureAwait(false);
+                    break;
+                case ReportChargesLabel:
+                    await CreateChargesReport(batchReport).ConfigureAwait(false);
+                    break;
+                case ReportOperatingBalancesByRentAccount:
+                    await CreateOperatingBalancesByRentAccount(batchReport).ConfigureAwait(false);
+                    break;
+                case ReportItemisedTransactionsLabel:
+                    await CreateItemisedTransactionsReport(batchReport).ConfigureAwait(false);
+                    break;
+                case ReportCashSuspenseLabel:
+                    await CreateCashSuspenseReport(batchReport).ConfigureAwait(false);
+                    break;
+                case ReportCashImportLabel:
+                    await CreateCashImportReport(batchReport).ConfigureAwait(false);
+                    break;
+                case ReportHousingBenefitAcademyLabel:
+                    await CreateHousingBenefitAcademyReport(batchReport).ConfigureAwait(false);
+                    break;
+                default:
+                    LoggingHandler.LogInfo($"Report label not found");
+                    break;
+            }
+
+            return new StepResponse() { Continue = true, NextStepTime = DateTime.Now.AddSeconds(int.Parse(_waitDuration)) };
         }
 
-        var folder = await _googleClientService
-            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        var fileName = $"Account_Balance_{rentgroup}_{reportDate}_{batchReport.Id}.csv";
-        var reportAccountBalances = (List<string[]>) await _reportGateway.GetReportAccountBalanceAsync(batchReport.ReportDate.Value, batchReport.RentGroup).ConfigureAwait(false);
-
-        await _googleClientService
-            .UploadCsvFile(reportAccountBalances, fileName, googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        System.Threading.Thread.Sleep(_sleepDuration);
-
-        var file = await _googleClientService
-            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-            .ConfigureAwait(false);
-
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
-    }
-
-    private async Task CreateChargesReport(BatchReportDomain batchReport)
-    {
-        var googleFileSetting = await GetGoogleFileSetting(ReportChargesLabel).ConfigureAwait(false);
-        if (googleFileSetting == null)
+        private async Task<GoogleFileSettingDomain> GetGoogleFileSetting(string label)
         {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
+            LoggingHandler.LogInfo($"Getting Google file settings for '{label}' label");
+            var googleFileSettings = await _googleFileSettingGateway.GetSettingsByLabel(label).ConfigureAwait(false);
+            LoggingHandler.LogInfo($"{googleFileSettings.Count} google file settings found");
+
+            return googleFileSettings.FirstOrDefault();
         }
 
-        var folder = await _googleClientService
-            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        var fileName = "";
-        var reportCharges = new List<string[]>();
-
-        if (!string.IsNullOrEmpty(batchReport.RentGroup))
+        private async Task CreateBalanceReportByDate(BatchReportDomain batchReport)
         {
-            fileName = $"Charges_{batchReport.RentGroup}_{batchReport.ReportYear}_{batchReport.Id}.csv";
-            reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAndRentGroupAsync(batchReport.ReportYear.Value, batchReport.RentGroup).ConfigureAwait(false);
-        }
-        else if (!string.IsNullOrEmpty(batchReport.Group))
-        {
-            fileName = $"Charges_{batchReport.Group}_{batchReport.ReportYear}_{batchReport.Id}.csv";
-            reportCharges = (List<string[]>) await _reportGateway.GetChargesByGroupTypeAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
-        }
-        else
-        {
-            fileName = $"Charges_{batchReport.ReportYear}_{batchReport.Id}.csv";
-            reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
-        }
+            var rentgroup = string.IsNullOrEmpty(batchReport.RentGroup) ? "ALL" : batchReport.RentGroup.Trim();
+            var reportDate = batchReport.ReportDate.Value.ToString("yyyyMMdd");
 
-        await _googleClientService
-            .UploadCsvFile(reportCharges, fileName, googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
+            var googleFileSetting = await GetGoogleFileSetting(ReportAccountBalanceByDateLabel).ConfigureAwait(false);
+            if (googleFileSetting == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
 
-        System.Threading.Thread.Sleep(_sleepDuration);
-
-        var file = await _googleClientService
-            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-            .ConfigureAwait(false);
-
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
-    }
-
-    private async Task CreateOperatingBalancesByRentAccount(BatchReportDomain batchReport)
-    {
-        var opBalsByRentAccFolderGFS = await GetGoogleFileSetting(ReportOperatingBalancesByRentAccount).ConfigureAwait(false);
-        if (opBalsByRentAccFolderGFS == null)
-        {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
-        }
-
-        var fileName = $"Operating_Balances_by_Rent_Account_{batchReport.RentGroup}" +
-            $"_y{batchReport.ReportYear}_s{batchReport.ReportStartWeekOrMonth}" +
-            $"_e{batchReport.ReportEndWeekOrMonth}_id{batchReport.Id}.csv";
-
-        var reportCharges = await _transactionGateway
-            .GetPRNTransactions(batchReport.ExtractPRNTransactionArgs())
-            .ConfigureAwait(false);
-
-        var csvFile = CSVHelper.ToCSVInMemoryFile(reportCharges, fileName);
-
-        await _googleClientService
-            .UploadFileOrThrow(csvFile, opBalsByRentAccFolderGFS.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        GD.File file = null;
-
-        var waitDurationInSeconds = _sleepDuration / 1000;
-        var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
-
-        do
-        {
-            System.Threading.Thread.Sleep(1000);
-
-            file = await _googleClientService
-                .GetFileByNameInDriveAsync(opBalsByRentAccFolderGFS.GoogleIdentifier, fileName)
+            var folder = await _googleClientService
+                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
                 .ConfigureAwait(false);
-        }
-        while (file is null && DateTime.Now < cuttoffTime);
 
-        if (file is null)
-        {
-            LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {opBalsByRentAccFolderGFS.GoogleIdentifier} directory.");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
-            return;
-        }
+            var fileName = $"Account_Balance_{rentgroup}_{reportDate}_{batchReport.Id}.csv";
+            var reportAccountBalances = (List<string[]>) await _reportGateway.GetReportAccountBalanceAsync(batchReport.ReportDate.Value, batchReport.RentGroup).ConfigureAwait(false);
 
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
-    }
-
-    private async Task CreateItemisedTransactionsReport(BatchReportDomain batchReport)
-    {
-        var itemisedTransactionFolderGFS = await GetGoogleFileSetting(ReportItemisedTransactionsLabel).ConfigureAwait(false);
-        if (itemisedTransactionFolderGFS == null)
-        {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
-        }
-
-        var fileName = $"Itemised_Transactions_{batchReport.TransactionType}_{batchReport.ReportYear}_{batchReport.Id}.csv";
-        var reportCharges = (List<string[]>) await _reportGateway
-            .GetItemisedTransactionsByYearAndTransactionTypeAsync(batchReport.ReportYear.Value, batchReport.TransactionType)
-            .ConfigureAwait(false);
-
-        await _googleClientService
-            .UploadCsvFile(reportCharges, fileName, itemisedTransactionFolderGFS.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        GD.File file = null;
-
-        var waitDurationInSeconds = _sleepDuration / 1000;
-        var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
-
-        do
-        {
-            System.Threading.Thread.Sleep(_retryInterval);
-
-            file = await _googleClientService
-                .GetFileByNameInDriveAsync(itemisedTransactionFolderGFS.GoogleIdentifier, fileName)
+            await _googleClientService
+                .UploadCsvFile(reportAccountBalances, fileName, googleFileSetting.GoogleIdentifier)
                 .ConfigureAwait(false);
-        }
-        while (file is null && DateTime.Now < cuttoffTime);
 
-        if (file is null)
+            System.Threading.Thread.Sleep(_sleepDuration);
+
+            var file = await _googleClientService
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .ConfigureAwait(false);
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+        }
+
+        private async Task CreateChargesReport(BatchReportDomain batchReport)
         {
-            LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {itemisedTransactionFolderGFS.GoogleIdentifier} directory.");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
-            return;
+            var googleFileSetting = await GetGoogleFileSetting(ReportChargesLabel).ConfigureAwait(false);
+            if (googleFileSetting == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var folder = await _googleClientService
+                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            var fileName = "";
+            var reportCharges = new List<string[]>();
+
+            if (!string.IsNullOrEmpty(batchReport.RentGroup))
+            {
+                fileName = $"Charges_{batchReport.RentGroup}_{batchReport.ReportYear}_{batchReport.Id}.csv";
+                reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAndRentGroupAsync(batchReport.ReportYear.Value, batchReport.RentGroup).ConfigureAwait(false);
+            }
+            else if (!string.IsNullOrEmpty(batchReport.Group))
+            {
+                fileName = $"Charges_{batchReport.Group}_{batchReport.ReportYear}_{batchReport.Id}.csv";
+                reportCharges = (List<string[]>) await _reportGateway.GetChargesByGroupTypeAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
+            }
+            else
+            {
+                fileName = $"Charges_{batchReport.ReportYear}_{batchReport.Id}.csv";
+                reportCharges = (List<string[]>) await _reportGateway.GetChargesByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
+            }
+
+            await _googleClientService
+                .UploadCsvFile(reportCharges, fileName, googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            System.Threading.Thread.Sleep(_sleepDuration);
+
+            var file = await _googleClientService
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .ConfigureAwait(false);
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
         }
 
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
-    }
-
-    private async Task CreateCashSuspenseReport(BatchReportDomain batchReport)
-    {
-        var googleFileSetting = await GetGoogleFileSetting(ReportCashSuspenseLabel).ConfigureAwait(false);
-        if (googleFileSetting == null)
+        private async Task CreateOperatingBalancesByRentAccount(BatchReportDomain batchReport)
         {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
+            var opBalsByRentAccFolderGFS = await GetGoogleFileSetting(ReportOperatingBalancesByRentAccount).ConfigureAwait(false);
+            if (opBalsByRentAccFolderGFS == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var fileName = $"Operating_Balances_by_Rent_Account_{batchReport.RentGroup}" +
+                $"_y{batchReport.ReportYear}_s{batchReport.ReportStartWeekOrMonth}" +
+                $"_e{batchReport.ReportEndWeekOrMonth}_id{batchReport.Id}.csv";
+
+            var reportCharges = await _transactionGateway
+                .GetPRNTransactions(batchReport.ExtractPRNTransactionArgs())
+                .ConfigureAwait(false);
+
+            var csvFile = CSVHelper.ToCSVInMemoryFile(reportCharges, fileName);
+
+            await _googleClientService
+                .UploadFileOrThrow(csvFile, opBalsByRentAccFolderGFS.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            GD.File file = null;
+
+            var waitDurationInSeconds = _sleepDuration / 1000;
+            var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
+
+            do
+            {
+                System.Threading.Thread.Sleep(1000);
+
+                file = await _googleClientService
+                    .GetFileByNameInDriveAsync(opBalsByRentAccFolderGFS.GoogleIdentifier, fileName)
+                    .ConfigureAwait(false);
+            }
+            while (file is null && DateTime.Now < cuttoffTime);
+
+            if (file is null)
+            {
+                LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {opBalsByRentAccFolderGFS.GoogleIdentifier} directory.");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
         }
 
-        var folder = await _googleClientService
-            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        var reportSuspenseAccount = (List<string[]>) await _reportGateway
-           .GetCashSuspenseAccountByYearAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
-
-        var fileName = $"Cash_Suspense_{batchReport.Group}_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
-
-        await _googleClientService
-            .UploadCsvFile(reportSuspenseAccount, fileName, googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        System.Threading.Thread.Sleep(_sleepDuration);
-
-        var file = await _googleClientService
-            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-            .ConfigureAwait(false);
-
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
-    }
-
-    private async Task CreateCashImportReport(BatchReportDomain batchReport)
-    {
-        var googleFileSetting = await GetGoogleFileSetting(ReportCashImportLabel).ConfigureAwait(false);
-        if (googleFileSetting == null)
+        private async Task CreateItemisedTransactionsReport(BatchReportDomain batchReport)
         {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
+            var itemisedTransactionFolderGFS = await GetGoogleFileSetting(ReportItemisedTransactionsLabel).ConfigureAwait(false);
+            if (itemisedTransactionFolderGFS == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var fileName = $"Itemised_Transactions_{batchReport.TransactionType}_{batchReport.ReportYear}_{batchReport.Id}.csv";
+            var reportCharges = (List<string[]>) await _reportGateway
+                .GetItemisedTransactionsByYearAndTransactionTypeAsync(batchReport.ReportYear.Value, batchReport.TransactionType)
+                .ConfigureAwait(false);
+
+            await _googleClientService
+                .UploadCsvFile(reportCharges, fileName, itemisedTransactionFolderGFS.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            GD.File file = null;
+
+            var waitDurationInSeconds = _sleepDuration / 1000;
+            var cuttoffTime = DateTime.Now.AddSeconds(waitDurationInSeconds);
+
+            do
+            {
+                System.Threading.Thread.Sleep(_retryInterval);
+
+                file = await _googleClientService
+                    .GetFileByNameInDriveAsync(itemisedTransactionFolderGFS.GoogleIdentifier, fileName)
+                    .ConfigureAwait(false);
+            }
+            while (file is null && DateTime.Now < cuttoffTime);
+
+            if (file is null)
+            {
+                LoggingHandler.LogInfo($"File with name: '{fileName}' was not found within the {itemisedTransactionFolderGFS.GoogleIdentifier} directory.");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Uploaded report file not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
         }
 
-        var folder = await _googleClientService
-            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        var reportCashImport = (List<string[]>) await _reportGateway
-            .GetCashImportByDateAsync(batchReport.ReportStartDate.Value, batchReport.ReportEndDate.Value).ConfigureAwait(false);
-
-        var fileName = $"Cash_Import_{batchReport.ReportStartDate.Value.ToString("ddMMyyyy")}_{batchReport.ReportEndDate.Value.ToString("ddMMyyyy")}_{batchReport.Id}.csv";
-
-        await _googleClientService
-            .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
-
-        System.Threading.Thread.Sleep(_sleepDuration);
-
-        var file = await _googleClientService
-            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-            .ConfigureAwait(false);
-
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
-    }
-
-    private async Task CreateHousingBenefitAcademyReport(BatchReportDomain batchReport)
-    {
-        var googleFileSetting = await GetGoogleFileSetting(ReportHousingBenefitAcademyLabel).ConfigureAwait(false);
-        if (googleFileSetting == null)
+        private async Task CreateCashSuspenseReport(BatchReportDomain batchReport)
         {
-            LoggingHandler.LogInfo($"Output folder not found");
-            await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
-            return;
+            var googleFileSetting = await GetGoogleFileSetting(ReportCashSuspenseLabel).ConfigureAwait(false);
+            if (googleFileSetting == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var folder = await _googleClientService
+                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            var reportSuspenseAccount = (List<string[]>) await _reportGateway
+               .GetCashSuspenseAccountByYearAsync(batchReport.ReportYear.Value, batchReport.Group).ConfigureAwait(false);
+
+            var fileName = $"Cash_Suspense_{batchReport.Group}_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
+
+            await _googleClientService
+                .UploadCsvFile(reportSuspenseAccount, fileName, googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            System.Threading.Thread.Sleep(_sleepDuration);
+
+            var file = await _googleClientService
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .ConfigureAwait(false);
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
         }
 
-        var folder = await _googleClientService
-            .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
+        private async Task CreateCashImportReport(BatchReportDomain batchReport)
+        {
+            var googleFileSetting = await GetGoogleFileSetting(ReportCashImportLabel).ConfigureAwait(false);
+            if (googleFileSetting == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
 
-        var reportCashImport = (List<string[]>) await _reportGateway
-            .GetHousingBenefitAcademyByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
+            var folder = await _googleClientService
+                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
 
-        var fileName = $"HB_Academy_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
+            var reportCashImport = (List<string[]>) await _reportGateway
+                .GetCashImportByDateAsync(batchReport.ReportStartDate.Value, batchReport.ReportEndDate.Value).ConfigureAwait(false);
 
-        await _googleClientService
-            .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
-            .ConfigureAwait(false);
+            var fileName = $"Cash_Import_{batchReport.ReportStartDate.Value.ToString("ddMMyyyy")}_{batchReport.ReportEndDate.Value.ToString("ddMMyyyy")}_{batchReport.Id}.csv";
 
-        System.Threading.Thread.Sleep(_sleepDuration);
+            await _googleClientService
+                .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
 
-        var file = await _googleClientService
-            .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
-            .ConfigureAwait(false);
+            System.Threading.Thread.Sleep(_sleepDuration);
 
-        var fileLink = $"https://drive.google.com/file/d/{file.Id}";
-        await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+            var file = await _googleClientService
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .ConfigureAwait(false);
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+        }
+
+        private async Task CreateHousingBenefitAcademyReport(BatchReportDomain batchReport)
+        {
+            var googleFileSetting = await GetGoogleFileSetting(ReportHousingBenefitAcademyLabel).ConfigureAwait(false);
+            if (googleFileSetting == null)
+            {
+                LoggingHandler.LogInfo($"Output folder not found");
+                await _batchReportGateway.SetStatusAsync(batchReport.Id, "Output folder not found", false).ConfigureAwait(false);
+                return;
+            }
+
+            var folder = await _googleClientService
+                .GetFilesInDriveAsync(googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            var reportCashImport = (List<string[]>) await _reportGateway
+                .GetHousingBenefitAcademyByYearAsync(batchReport.ReportYear.Value).ConfigureAwait(false);
+
+            var fileName = $"HB_Academy_{batchReport.ReportYear.Value}_{batchReport.Id}.csv";
+
+            await _googleClientService
+                .UploadCsvFile(reportCashImport, fileName, googleFileSetting.GoogleIdentifier)
+                .ConfigureAwait(false);
+
+            System.Threading.Thread.Sleep(_sleepDuration);
+
+            var file = await _googleClientService
+                .GetFileByNameInDriveAsync(googleFileSetting.GoogleIdentifier, fileName)
+                .ConfigureAwait(false);
+
+            var fileLink = $"https://drive.google.com/file/d/{file.Id}";
+            await _batchReportGateway.SetStatusAsync(batchReport.Id, fileLink, true).ConfigureAwait(false);
+        }
     }
 }
-

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -216,7 +216,7 @@ namespace HousingFinanceInterimApi.V1.UseCase
 
             do
             {
-                System.Threading.Thread.Sleep(1000);
+                System.Threading.Thread.Sleep(_retryInterval);
 
                 file = await _googleClientService
                     .GetFileByNameInDriveAsync(opBalsByRentAccFolderGFS.GoogleIdentifier, fileName)

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -11,7 +11,8 @@ using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Handlers;
 using HousingFinanceInterimApi.V1.Helpers;
 
-namespace HousingFinanceInterimApi.V1.UseCase {
+namespace HousingFinanceInterimApi.V1.UseCase
+{
     public class GenerateReportUseCase : IGenerateReportUseCase
     {
         private readonly IBatchReportGateway _batchReportGateway;

--- a/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/GenerateReportUseCase.cs
@@ -24,9 +24,8 @@ public class GenerateReportUseCase : IGenerateReportUseCase
     //private readonly IReportSuspenseAccountGateway _reportSuspenseAccountGateway;
     private readonly IGoogleFileSettingGateway _googleFileSettingGateway;
     private readonly IGoogleClientService _googleClientService;
-
     private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION");
-    private readonly int _sleepDuration = 1000;
+    private readonly int _sleepDuration;
 
     private const string ReportAccountBalanceByDateLabel = "ReportAccountBalanceByDate";
     private const string ReportChargesLabel = "ReportCharges";
@@ -41,13 +40,16 @@ public class GenerateReportUseCase : IGenerateReportUseCase
         IReportGateway reportGateway,
         ITransactionGateway transactionGateway,
         IGoogleFileSettingGateway googleFileSettingGateway,
-        IGoogleClientService googleClientService)
+        IGoogleClientService googleClientService,
+        int sleepDuration = 30_000
+        )
     {
         _batchReportGateway = batchReportGateway;
         _reportGateway = reportGateway;
         _transactionGateway = transactionGateway;
         _googleFileSettingGateway = googleFileSettingGateway;
         _googleClientService = googleClientService;
+        _sleepDuration = sleepDuration;
     }
 
     public async Task<StepResponse> ExecuteAsync()
@@ -257,7 +259,7 @@ public class GenerateReportUseCase : IGenerateReportUseCase
 
         do
         {
-            System.Threading.Thread.Sleep(1000);
+            System.Threading.Thread.Sleep(200);
 
             file = await _googleClientService
                 .GetFileByNameInDriveAsync(itemisedTransactionFolderGFS.GoogleIdentifier, fileName)

--- a/HousingFinanceInterimApi/V1/UseCase/Interfaces/IGenerateReportUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/Interfaces/IGenerateReportUseCase.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using HousingFinanceInterimApi.V1.Domain;
 using System.Threading.Tasks;
 using HousingFinanceInterimApi.V1.Boundary.Response;
 


### PR DESCRIPTION
Speed up the HFS reports use case tests from ~15 minutes running time to ~1 minute by allowing file wait and retry durations to be modified.

This cuts down the CI pipeline duration to ~2.5 minutes, as the reports UC tests were the bottleneck. The reports UC made use of hard time waits and retry intervals which ran far longer than is needed in unit tests that aren't connected to real infrastructure. 

This PR modifies the `GenerateReportUseCase` to take in optional `sleepDuration` and `retryInterval` params that retain the original values as defaults, but can be overridden in the tests or elsewhere in the application as needed. It also ensures the UC reports are generated and checked using a retry mechanism and a timeout similar to how it was already done in one of the reports, instead of just hard wait duration.

Time calculations in the tests often assumed the default values for sleep and retry durations, so they have been modified accordingly.