### PR TITLE
🤦 Fix serverless deploy command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,6 @@ commands:
       - node/install-packages:
           app-dir: HousingFinanceInterimApi
       - run:
-          name: Install step function plugin
-          command: npm i serverless-step-functions
-      - run:
           name: Build lambda
           command: |
             cd ./HousingFinanceInterimApi/
@@ -64,8 +61,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./HousingFinanceInterimApi/
-            npm i serverless-associate-waf
-            sls deploy --stage <<parameters.stage>> --conceal
+            npx --yes serverless deploy --stage <<parameters.stage>> --conceal
 
 jobs:
   check-code-formatting:


### PR DESCRIPTION
In https://github.com/LBHackney-IT/housing-finance-interim-api/pull/162 I introduced `package.json` to manage Serverless plugins (because it's recommended by the docs and the existing approach failed in CI), however I failed to do two things:

1. Actually install Serverless 4. The change was _supposed_ to switch from using `npm install -g serverless@3` followed by executing `sls` to a single use of `npx --yes serverless deploy`. In #162 I removed the global install step but didn't update how we called serverless 🤦.

2. Removing the plugin install steps, so it attempted to install them twice 🤦.

The first mistake caused the CircleCI pipeline to fail. This change rectifies that.

So, double facepalm. Sorry!

### *Follow up actions after merging PR*

- Check the CircleCI build completes
