### PR TITLE
🤦 Update all .Net refs to 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"


### PR DESCRIPTION
In https://github.com/LBHackney-IT/housing-finance-interim-api/pull/163 we upgraded .Net from 6 to 8, but missed one reference in the CircleCI config, which caused the build to fail.

This change fixes that.

Sorry for the flurry of fix PRs @Duslerke 