### PR TITLE
Update CODEOWNERS with the new Github team group.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,4 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
+# This file specifies owners for pull request approval
+# See https://help.github.com/articles/about-code-owners/
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @FaisalHackney @Duslerke @LBHackney-IT/mtfh-finance
+* @LBHackney-IT/housing-products


### PR DESCRIPTION
# What:
 - Update the `CODEOWNERS` to be defined through a new Github group.

# Why:
 - Previous Github groups have been deleted.

# Notes:
 - Redoing this PR as we're fixing this repository's branching history, and removing some WIP features that are unlikely to be finished any time soon.
 - It was easier to just redo the change manually than mess about with cherry picking due to various merge conflicts undergone along the way.
 - This work redoes the work done in PR #170 .
 - The branch is currently named `first` to get around the branch protection deadlock relating to dated CODEOWNERs. The branch will be renamed to `master` later.