### PR TITLE
Apply `dotnet8` upgrade to the cleaned soon-to-be main branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/HousingFinanceInterimApi.Tests/Dockerfile
+++ b/HousingFinanceInterimApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/HousingFinanceInterimApi.Tests/Dockerfile
+++ b/HousingFinanceInterimApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0.300
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
@@ -23,4 +23,4 @@ COPY . .
 
 RUN dotnet build ./HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
 
-CMD dotnet test
+CMD dotnet test 

--- a/HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
+++ b/HousingFinanceInterimApi.Tests/HousingFinanceInterimApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/HousingFinanceInterimApi/Dockerfile
+++ b/HousingFinanceInterimApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/HousingFinanceInterimApi/HousingFinanceInterimApi.csproj
+++ b/HousingFinanceInterimApi/HousingFinanceInterimApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/HousingFinanceInterimApi/build.cmd
+++ b/HousingFinanceInterimApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/housing-finance-interim-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/housing-finance-interim-api.zip

--- a/HousingFinanceInterimApi/build.sh
+++ b/HousingFinanceInterimApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/housing-finance-interim-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/housing-finance-interim-api.zip

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -2,7 +2,7 @@ service: housing-finance-interim-api
 provider:
   name: aws
   timeout: 300
-  runtime: dotnet6
+  runtime: dotnet8
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
@@ -28,7 +28,7 @@ provider:
     HOUSING_FINANCE_ALLOWED_GROUPS: ${ssm:/housing-finance/${self:provider.stage}/housing-finance-allowed-groups}
 
 package:
-  artifact: ./bin/release/net6.0/housing-finance-interim-api.zip
+  artifact: ./bin/release/net8.0/housing-finance-interim-api.zip
 
 functions:
   interimFinanceSystem:


### PR DESCRIPTION
# What:
 - Bump the application to `.NET 8`.
 - Remove unused CircleCI orbs.

# Why:
 - The `.NET 6` has been deprecated.

# Notes:
 - This PR redoes the `.NET 8` upgrade work done behind the PRs being released in PR #177.
 - Work has to be redone because we're cleaning up the git history of old `master` and `development` branches _(renamed with today's date suffix)_. It's easier to just redo the changes as moving the existing commits from other branches requires resolving multiple merge conflicts. Plus, the serverless v4 upgrade contained within those changes isn't the best way to upgrade serverless.
 - The `.NET 8` changes have been released to live environment about a week ago, and no adverse effects were noticed. Upgrade was successful, as such, this PR is merely a formality to keep track of how the changes were introduced into what's soon to become a main branch.
 - Tests seem to have some flakiness relating to 'datetime now', but have passed just fine.

# Screenshots:

| ![image](https://github.com/user-attachments/assets/e661ac16-fe60-4b54-ba18-018563a6a307) |
| --- |
| The docker tests container has to be rolled back to an older sdk base image patch version as the new version _(8.0.408 at the time of writing)_ was failing to forward dotnet test logs back to host's stdout, which in turn caused CircleCI to time out due to 10 minutes of perceived inactivity. Seems to be a bug at Microsoft's or their dependency's end. As can be seen from this passing tests screenshot taken after version was capped at 8.0.300, the tests take ~15 minutes to run, so they're bound to time out w/o logs being forwarded. |

| ![image](https://github.com/user-attachments/assets/280736ef-94db-44ef-8bae-a5d4081b4239) |
| --- |
| It's possible that the above-described issue was present for a while, but was simply obscured by failed/incorrect filter condition when launching the tests. This would mean that we possibly had no real feedback from tests run for longer than what this feature branch has experienced. This logs screenshot is taken from the `master_2025-04-16` branch which used to be the old `master`. |