### PR TITLE
Point the HFS Interim API to the upgraded version of the authoriser.

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -40,7 +40,7 @@ functions:
           path: /{proxy+}
           method: ANY
           authorizer:
-            arn: ${ssm:/api-authenticator/${self:provider.stage}/arn}
+            arn: arn: ${self:custom.authorizerArns.${opt:stage}}
             type: request
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -885,6 +885,10 @@ resources:
             Value: ${self:service}-${self:provider.stage}-refresh-ma-cur-bal
 
 custom:
+  authorizerArns:
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   associateWaf:
     name: Platform_APIs_Web_ACL
     version: V2


### PR DESCRIPTION
# What:
 - Make the HFS API use the authoriser version running on an upgraded .NET version.

# Why:
 - Authoriser has moved on from the long not supported .NET core 3.1

# Notes:
 - This PR merely replicates the PR #176 changes. It has to be replicated due to branch clean up work.