### PR TITLE
Upgrade Serverless Framework from v3 to v4.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  node: circleci/node@6.3.0
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
       - node/install
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless@^3
+          command: npm i -g serverless
       - run:
           name: Install step function plugin          
           command: npm i serverless-step-functions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ workflows:
       - deploy-to-development:
           context:
             - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - assume-role-development  
           filters:
@@ -159,6 +160,7 @@ workflows:
       - deploy-to-staging:
           context:
             - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - assume-role-staging
           filters:
@@ -181,6 +183,7 @@ workflows:
       - deploy-to-production:
           context:
             - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - permit-production-release
             - assume-role-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
       - run:
           name: Install serverless CLI
           command: npm i -g serverless@^3


### PR DESCRIPTION
# What:
 - Bump serverless framework from v3 to v4.
 - Authenticate serverless framework with prepared CCI context.

# Why:
 - Serverless framework v3 is reaching it's EOL.

# Notes:
 - This upgrade was done in a slightly different way in the PRs prior. This is because, ideally, we don't want to have package.json and lock files within a C# repository.