### PR TITLE
Fix duplicated ARN key typo.

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -40,7 +40,7 @@ functions:
           path: /{proxy+}
           method: ANY
           authorizer:
-            arn: arn: ${self:custom.authorizerArns.${opt:stage}}
+            arn: ${self:custom.authorizerArns.${opt:stage}}
             type: request
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization


### PR DESCRIPTION
# What:
 - Fix a duplicated ARN typo.

# Why:
 - Made a mistake when moving the changes between the branches.