### PR TITLE
Automatically prune stale AWS Lambda function versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./HousingFinanceInterimApi/
-            npm i serverless-associate-waf
+            npm i serverless-associate-waf serverless-prune-plugin
             sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -885,6 +885,10 @@ resources:
             Value: ${self:service}-${self:provider.stage}-refresh-ma-cur-bal
 
 custom:
+  prune:
+    automatic: true
+    number: 10
+    includeLayers: true
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
@@ -915,3 +919,4 @@ custom:
 plugins:
   - serverless-step-functions
   - serverless-associate-waf
+  - serverless-prune-plugin


### PR DESCRIPTION
# What:
 - Attempt at configuring automatic old Lambda Versions and Layer versions pruning.

# Why:
 - We've hit 75GB limit for the AWS account for lambda code storage.

# Notes:
 - See the official documentation: [[link](https://www.npmjs.com/package/serverless-prune-plugin)].