### PR TITLE
Extend the CircleCI lambda deployment step no output timeout step window from 10m to 45m.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
           name: Install serverless CLI
           command: npm i -g serverless
       - run:
-          name: Install step function plugin          
+          name: Install step function plugin
           command: npm i serverless-step-functions
       - run:
           name: Build lambda
@@ -61,6 +61,7 @@ commands:
             ./build.sh      
       - run:
           name: Deploy lambda
+          no_output_timeout: 45m
           command: |
             cd ./HousingFinanceInterimApi/
             npm i serverless-associate-waf serverless-prune-plugin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
           command: |
             cd ./HousingFinanceInterimApi/
             npm i serverless-associate-waf serverless-prune-plugin
-            sls deploy --stage <<parameters.stage>> --conceal
+            sls deploy --stage <<parameters.stage>>
 
 jobs:
   check-code-formatting:


### PR DESCRIPTION
# What:
 - Extend the CCI sls deployment step no output timeout from 10m to 45m.
 - Remove the conceal from the deployment command.

# Why:
 - Permit long running operations to complete.
 - No need to conceal deployment output when it's the last step of the job. Best to see what the process is hanging on or what it failed on.