### PR TITLE
Fix InvalidOperationException

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/UseCase/NightlyProcessLogUseCaseTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/UseCase/NightlyProcessLogUseCaseTests.cs
@@ -6,6 +6,7 @@ using Amazon.CloudWatchLogs;
 using Amazon.CloudWatchLogs.Model;
 using FluentAssertions;
 using HousingFinanceInterimApi.V1.Gateway.Interfaces;
+using HousingFinanceInterimApi.V1.Helpers;
 using HousingFinanceInterimApi.V1.Infrastructure;
 using HousingFinanceInterimApi.V1.UseCase;
 using Microsoft.EntityFrameworkCore;
@@ -18,12 +19,14 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
     {
         private readonly Mock<IAmazonCloudWatchLogs> _mockCloudWatchLogsClient;
         private readonly Mock<INightlyProcessLogGateway> _mockGateway;
+        private readonly Mock<ILogGroupProvider> _mockProvider;
         private NightlyProcessLogUseCase _nightlyProcessLogUseCase;
 
         public NightlyProcessLogUseCaseTests()
         {
             _mockGateway = new Mock<INightlyProcessLogGateway>();
             _mockCloudWatchLogsClient = new Mock<IAmazonCloudWatchLogs>();
+            _mockProvider = new Mock<ILogGroupProvider>();
         }
 
         [Fact]
@@ -31,7 +34,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         {
             // Arrange
             var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             var queryResults = new List<List<ResultField>> { new List<ResultField> { new ResultField { Field = "Test", Value = "Value" } } };
 
@@ -42,6 +45,10 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             _mockCloudWatchLogsClient
                 .Setup(x => x.GetQueryResultsAsync(It.IsAny<GetQueryResultsRequest>(), default))
                 .ReturnsAsync(new GetQueryResultsResponse { Status = QueryStatus.Complete, Results = queryResults });
+
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
 
             // Act
             var results = await _nightlyProcessLogUseCase.QueryCloudWatchLogs(logGroups[0]).ConfigureAwait(false);
@@ -56,7 +63,7 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         {
             // Arrange
             var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             _mockCloudWatchLogsClient
                 .Setup(x => x.StartQueryAsync(It.IsAny<StartQueryRequest>(), default))
@@ -65,6 +72,10 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             _mockCloudWatchLogsClient
                 .Setup(x => x.GetQueryResultsAsync(It.IsAny<GetQueryResultsRequest>(), default))
                 .ReturnsAsync(new GetQueryResultsResponse { Status = QueryStatus.Failed });
+
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
 
             // Act
             Func<Task> act = async () => await _nightlyProcessLogUseCase.QueryCloudWatchLogs(logGroups[0]).ConfigureAwait(false);
@@ -77,11 +88,6 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         public async Task ExecuteAsync_Should_Process_LogGroups_InSequence()
         {
             // Arrange
-            var logGroups = new List<string> { "/aws/lambda/log-group-function1", "/aws/lambda/log-group-function2" };
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
-
-            var queryResults = new List<List<ResultField>> { new List<ResultField> { new ResultField { Field = "Test", Value = "Value" } } };
-
             _mockGateway
                 .Setup(x => x.UpdateDatabaseWithResults(It.IsAny<string>(), It.IsAny<List<List<ResultField>>>()))
                 .Returns(Task.CompletedTask);
@@ -90,9 +96,17 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .Setup(x => x.StartQueryAsync(It.IsAny<StartQueryRequest>(), default))
                 .ReturnsAsync(new StartQueryResponse { QueryId = "test-query-id" });
 
+            var queryResults = new List<List<ResultField>> { new List<ResultField> { new ResultField { Field = "Test", Value = "Value" } } };
             _mockCloudWatchLogsClient
                 .Setup(x => x.GetQueryResultsAsync(It.IsAny<GetQueryResultsRequest>(), default))
                 .ReturnsAsync(new GetQueryResultsResponse { Status = QueryStatus.Complete, Results = queryResults });
+
+            var logGroups = new List<string> { "/aws/lambda/log-group-function1", "/aws/lambda/log-group-function2" };
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
+
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             // Act
             var response = await _nightlyProcessLogUseCase.ExecuteAsync().ConfigureAwait(false);
@@ -109,9 +123,6 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         public async Task ExecuteAsync_Should_Log_Any_Errors_And_Continues_Processing()
         {
             // Arrange
-            var logGroups = new List<string> { "log-group-1", "log-group-2" };
-            var useCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
-
             _mockCloudWatchLogsClient
                 .SetupSequence(x => x.StartQueryAsync(It.IsAny<StartQueryRequest>(), default))
                 .ReturnsAsync(new StartQueryResponse { QueryId = "query-id-1" })
@@ -132,8 +143,15 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 .Setup(x => x.UpdateDatabaseWithResults(It.IsAny<string>(), It.IsAny<List<List<ResultField>>>()))
                 .Returns(Task.CompletedTask);
 
+            var logGroups = new List<string> { "log-group-1", "log-group-2" };
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
+
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
+
             // Act
-            var response = await useCase.ExecuteAsync();
+            var response = await _nightlyProcessLogUseCase.ExecuteAsync().ConfigureAwait(false);
 
             // Assert
             Assert.NotNull(response);
@@ -152,7 +170,11 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // Arrange
             var createdDate = default(DateTime);
             var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
+
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
 
             // Act & Assert
             await Assert.ThrowsAsync<ArgumentException>(() => _nightlyProcessLogUseCase.ExecuteAsync(createdDate)).ConfigureAwait(false);
@@ -163,12 +185,16 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         {
             // Arrange
             var createdDate = DateTime.UtcNow;
-            var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
-
             _mockGateway
                 .Setup(x => x.GetByDateCreatedAsync(createdDate))
                 .ReturnsAsync(new List<NightlyProcessLog>());
+
+            var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
+
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             // Act
             var result = await _nightlyProcessLogUseCase.ExecuteAsync(createdDate).ConfigureAwait(false);
@@ -184,7 +210,6 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
         {
             // Arrange
             var createdDate = DateTime.UtcNow.Date;
-            var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
             var logs = new List<NightlyProcessLog>
             {
                 new NightlyProcessLog
@@ -197,11 +222,16 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
                 }
             };
 
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             _mockGateway
                 .Setup(x => x.GetByDateCreatedAsync(createdDate))
                 .ReturnsAsync(logs);
+
+            var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
 
             // Act
             var result = await _nightlyProcessLogUseCase.ExecuteAsync(createdDate).ConfigureAwait(false);
@@ -218,10 +248,16 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // Arrange
             var createdDate = DateTime.UtcNow;
             var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
+
             _mockGateway
                 .Setup(x => x.GetByDateCreatedAsync(createdDate))
                 .Throws(new DbUpdateException("Database error"));
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
+
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
+
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             // Act & Assert
             await Assert.ThrowsAsync<System.InvalidOperationException>(() => _nightlyProcessLogUseCase.ExecuteAsync(createdDate)).ConfigureAwait(false);
@@ -233,11 +269,15 @@ namespace HousingFinanceInterimApi.Tests.V1.UseCase
             // Arrange
             var createdDate = DateTime.UtcNow;
             var logGroups = new List<string> { "/aws/lambda/log-group-function1" };
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, logGroups);
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(_mockGateway.Object, _mockCloudWatchLogsClient.Object, _mockProvider.Object);
 
             _mockGateway
                 .Setup(x => x.GetByDateCreatedAsync(createdDate))
                 .Throws(new Exception("Unexpected error"));
+
+            _mockProvider
+                .Setup(x => x.GetLogGroups(It.IsAny<string>()))
+                .Returns(logGroups);
 
             // Act & Assert
             await Assert.ThrowsAsync<ApplicationException>(() => _nightlyProcessLogUseCase.ExecuteAsync(createdDate)).ConfigureAwait(false);

--- a/HousingFinanceInterimApi/Handler.cs
+++ b/HousingFinanceInterimApi/Handler.cs
@@ -55,7 +55,6 @@ namespace HousingFinanceInterimApi
             DbContextOptionsBuilder optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer(Environment.GetEnvironmentVariable("CONNECTION_STRING"));
             DatabaseContext context = new DatabaseContext(optionsBuilder.Options);
-            var logGroups = LogGroupUtility.GetLogGroups(Environment.GetEnvironmentVariable("ENVIRONMENT_NAME"));
 
             var options = Options.Create(new GoogleClientServiceOptions
             {
@@ -133,7 +132,7 @@ namespace HousingFinanceInterimApi
                 reportGateway, transactionGateway, googleFileSettingGateway, googleClientService);
             _moveHousingBenefitFileUseCase = new MoveHousingBenefitFileUseCase(batchLogGateway, batchLogErrorGateway,
                 googleFileSettingGateway, googleClientService);
-            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(nightlyProcessLogGateway, new AmazonCloudWatchLogsClient(), logGroups);
+            _nightlyProcessLogUseCase = new NightlyProcessLogUseCase(nightlyProcessLogGateway, new AmazonCloudWatchLogsClient(), new LogGroupProvider());
         }
 
         public async Task<StepResponse> LoadTenancyAgreement()

--- a/HousingFinanceInterimApi/Startup.cs
+++ b/HousingFinanceInterimApi/Startup.cs
@@ -24,6 +24,7 @@ using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using Hackney.Core.JWT;
 using HousingFinanceInterimApi.V1.Gateway.Interfaces;
 using Amazon.CloudWatchLogs;
+using HousingFinanceInterimApi.V1.Helpers;
 
 namespace HousingFinanceInterimApi
 {
@@ -176,6 +177,7 @@ namespace HousingFinanceInterimApi
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddScoped<IGetBatchLogErrorUseCase, GetBatchLogErrorUseCase>();
+            services.AddSingleton<ILogGroupProvider, LogGroupProvider>();
             services.AddScoped<INightlyProcessLogUseCase, NightlyProcessLogUseCase>();
         }
 

--- a/HousingFinanceInterimApi/V1/Helpers/ILogGroupProvider.cs
+++ b/HousingFinanceInterimApi/V1/Helpers/ILogGroupProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace HousingFinanceInterimApi.V1.Helpers
+{
+    public interface ILogGroupProvider
+    {
+        List<string> GetLogGroups(string environmentName);
+    }
+}

--- a/HousingFinanceInterimApi/V1/Helpers/LogGroupProvider.cs
+++ b/HousingFinanceInterimApi/V1/Helpers/LogGroupProvider.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace HousingFinanceInterimApi.V1.Helpers
+{
+    public class LogGroupProvider : ILogGroupProvider
+    {
+        public List<string> GetLogGroups(string environmentName)
+        {
+            var logGroups = LogGroupUtility.GetLogGroups(environmentName);
+            return logGroups;
+        }
+    }
+}

--- a/HousingFinanceInterimApi/V1/UseCase/NightlyProcessLogUseCase.cs
+++ b/HousingFinanceInterimApi/V1/UseCase/NightlyProcessLogUseCase.cs
@@ -4,6 +4,7 @@ using HousingFinanceInterimApi.V1.Boundary.Response;
 using HousingFinanceInterimApi.V1.Domain;
 using HousingFinanceInterimApi.V1.Gateway.Interfaces;
 using HousingFinanceInterimApi.V1.Handlers;
+using HousingFinanceInterimApi.V1.Helpers;
 using HousingFinanceInterimApi.V1.Infrastructure;
 using HousingFinanceInterimApi.V1.UseCase.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -26,17 +27,20 @@ namespace HousingFinanceInterimApi.V1.UseCase
     {
         private readonly INightlyProcessLogGateway _nightlyprocessLogGateway;
         private readonly IAmazonCloudWatchLogs _cloudWatchLogsClient;
-        private readonly IList<string> _logGroups;
+        private readonly ILogGroupProvider _logGroupProvider;
+        private readonly List<string> _logGroups;
         private readonly string _waitDuration = Environment.GetEnvironmentVariable("WAIT_DURATION") ?? "100";
 
         public NightlyProcessLogUseCase(
             INightlyProcessLogGateway nightlyprocessLogGateway,
             IAmazonCloudWatchLogs cloudWatchLogsClient,
-            IList<string> logGroups)
+            ILogGroupProvider logGroupProvider)
         {
             _nightlyprocessLogGateway = nightlyprocessLogGateway;
             _cloudWatchLogsClient = cloudWatchLogsClient;
-            _logGroups = logGroups ?? throw new ArgumentNullException(nameof(logGroups));
+            _logGroupProvider = logGroupProvider;
+            _logGroups = _logGroupProvider.GetLogGroups(Environment.GetEnvironmentVariable("ENVIRONMENT_NAME"));
+            
         }
 
         public async Task<StepResponse> ExecuteAsync()


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/HPT-656

Previously NightlyProcessLogUseCase was throwing an error because the use of the concrete IList<> for containing LogGroups was throwing an InvalidOperationException because of Dependency Injection issues.

So, swapped out the concrete static class and used an interface, registered as a Singleton.