### PR TITLE
Only return last log per log group

### DIFF
--- a/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
@@ -234,7 +234,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             var sequence = new MockSequence();
 
             var errorResults = new List<List<ResultField>>
-            { 
+            {
                 new List<ResultField>
                 {
                     new ResultField { Field = "@timestamp", Value = today.AddMinutes(-10).ToString("o") },
@@ -244,10 +244,10 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
 
             var successResults = new List<List<ResultField>>();
 
-            NightlyProcessLog lastLogSaved = null; 
+            NightlyProcessLog lastLogSaved = null;
 
             _mockDbSet.Setup(x => x.AddAsync(It.IsAny<NightlyProcessLog>(), It.IsAny<System.Threading.CancellationToken>()))
-                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((log, token) => 
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((log, token) =>
                 {
                     lastLogSaved = log;
                 })
@@ -259,9 +259,9 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
 
             // 3. Assert
             Assert.NotNull(lastLogSaved);
-        
+
             Assert.True(lastLogSaved.IsSuccess);
-            
+
             Assert.Equal(logGroupName, lastLogSaved.LogGroupName);
         }
 
@@ -274,7 +274,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             var sequence = new MockSequence();
 
             var errorResults = new List<List<ResultField>>
-            { 
+            {
                 new List<ResultField>
                 {
                     new ResultField { Field = "@timestamp", Value = today.ToString("o") },
@@ -284,10 +284,10 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
 
             var successResults = new List<List<ResultField>>();
 
-            NightlyProcessLog lastLogSaved = null; 
+            NightlyProcessLog lastLogSaved = null;
 
             _mockDbSet.Setup(x => x.AddAsync(It.IsAny<NightlyProcessLog>(), It.IsAny<System.Threading.CancellationToken>()))
-                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((log, token) => 
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((log, token) =>
                 {
                     lastLogSaved = log;
                 })
@@ -299,9 +299,9 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
 
             // Assert
             Assert.NotNull(lastLogSaved);
-        
+
             Assert.False(lastLogSaved.IsSuccess);
-            
+
             Assert.Equal(logGroupName, lastLogSaved.LogGroupName);
         }
 
@@ -316,7 +316,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             var finalStates = new Dictionary<string, bool>();
 
             var errorResults = new List<List<ResultField>>
-            { 
+            {
                 new List<ResultField>
                 {
                     new ResultField { Field = "@timestamp", Value = today.ToString("o") },
@@ -335,7 +335,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
                 .Callback<NightlyProcessLog, System.Threading.CancellationToken>((l, t) => finalStates[firstLogGroup] = l.IsSuccess.GetValueOrDefault())
                 .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
 
-            // SCRIPT STEP 3 & 4: Group 2 goes from Error to Success
+            // SCRIPT STEP 3 & 4: Group 2 goes from Success to Error
             _mockDbSet.InSequence(sequence).Setup(x => x.AddAsync(It.Is<NightlyProcessLog>(l => l.LogGroupName == secondLogGroup && l.IsSuccess.GetValueOrDefault() == true), It.IsAny<System.Threading.CancellationToken>()))
                 .Callback<NightlyProcessLog, System.Threading.CancellationToken>((l, t) => finalStates[secondLogGroup] = l.IsSuccess.GetValueOrDefault())
                 .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);

--- a/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
@@ -30,7 +30,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_ShouldSaveToDatabaseAsFail_WhenValidInputHasError()
+        public async Task UpdateDatabaseWithResultsShouldSaveToDatabaseAsFailWhenValidInputHasError()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -52,7 +52,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_ShouldThrowArgumentNullException_WhenLogGroupNameIsNull()
+        public async Task UpdateDatabaseWithResultsShouldThrowArgumentNullExceptionWhenLogGroupNameIsNull()
         {
             // Arrange
             string logGroupName = null;
@@ -64,7 +64,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_ShouldLogAndThrow_WhenDbUpdateException()
+        public async Task UpdateDatabaseWithResultsShouldLogAndThrowWhenDbUpdateException()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -87,7 +87,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_ShouldAddFailure_WhenErrorExists()
+        public async Task UpdateDatabaseWithResultsShouldAddFailureWhenErrorExists()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -114,7 +114,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_ShouldStopProcessingOnFirstError()
+        public async Task UpdateDatabaseWithResultsShouldStopProcessingOnFirstError()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -141,7 +141,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_Case1_ResultsExistForKeyword()
+        public async Task UpdateDatabaseWithResultsCase1ResultsExistForKeyword()
         {
             // Arrange
             var logGroupName = "test-log-group";
@@ -155,7 +155,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             };
 
             // Act
-            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults);
+            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults).ConfigureAwait(false);
 
             // Assert
             _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(It.Is<NightlyProcessLog>(log =>
@@ -165,14 +165,14 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_Case2_LogsExistButNoMatchForKeyword()
+        public async Task UpdateDatabaseWithResultsCase2LogsExistButNoMatchForKeyword()
         {
             // Arrange
             var logGroupName = "test-log-group";
             var queryResults = new List<List<ResultField>>();
 
             // Act
-            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults);
+            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults).ConfigureAwait(false);
 
             // Assert
             _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(It.Is<NightlyProcessLog>(log =>
@@ -182,14 +182,14 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_Case3_NoLogsExistForLogGroup()
+        public async Task UpdateDatabaseWithResultsCase3NoLogsExistForLogGroup()
         {
             // Arrange
             var logGroupName = "test-log-group";
             List<List<ResultField>> queryResults = null;
 
             // Act
-            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults);
+            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults).ConfigureAwait(false);
 
             // Assert
             _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(It.Is<NightlyProcessLog>(log =>
@@ -199,7 +199,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResults_Case4_LogsExistButMandatorySuccessMessageMissing()
+        public async Task UpdateDatabaseWithResultsCase4LogsExistButMandatorySuccessMessageMissing()
         {
             // Arrange
             var logGroupName = "test-log-group";
@@ -214,17 +214,17 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             };
 
             // Act
-            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults);
+            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults).ConfigureAwait(false);
 
             // Assert
             _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
                 It.Is<NightlyProcessLog>(log =>
                     log.LogGroupName == logGroupName &&
-                    log.IsSuccess == false), 
+                    log.IsSuccess == false),
                 It.IsAny<System.Threading.CancellationToken>()),
                 Times.Once);
         }
-        
+
         [Fact]
         public async Task ProcessingMultipleLogGroupsSavesOneResultPerGroup()
         {
@@ -233,32 +233,32 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             var secondLogGroup = "log-group-2";
 
             var results1 = new List<List<ResultField>> {
-                new List<ResultField> { 
+                new List<ResultField> {
                     new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("o") },
-                    new ResultField { Field = "@message", Value = "Error in group 1" } 
+                    new ResultField { Field = "@message", Value = "Error in group 1" }
                 }
             };
 
             var results2 = new List<List<ResultField>> {
-                new List<ResultField> { 
+                new List<ResultField> {
                     new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("o") },
-                    new ResultField { Field = "@message", Value = "Error in group 2" } 
+                    new ResultField { Field = "@message", Value = "Error in group 2" }
                 }
             };
 
             // Act
-            await _gateway.UpdateDatabaseWithResults(firstLogGroup, results1);
-            await _gateway.UpdateDatabaseWithResults(secondLogGroup, results2);
+            await _gateway.UpdateDatabaseWithResults(firstLogGroup, results1).ConfigureAwait(false);
+            await _gateway.UpdateDatabaseWithResults(secondLogGroup, results2).ConfigureAwait(false);
 
             // Assert
             _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
-                It.Is<NightlyProcessLog>(log => log.LogGroupName == firstLogGroup), 
-                It.IsAny<System.Threading.CancellationToken>()), 
+                It.Is<NightlyProcessLog>(log => log.LogGroupName == firstLogGroup),
+                It.IsAny<System.Threading.CancellationToken>()),
                 Times.Once);
 
             _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
-                It.Is<NightlyProcessLog>(log => log.LogGroupName == secondLogGroup), 
-                It.IsAny<System.Threading.CancellationToken>()), 
+                It.Is<NightlyProcessLog>(log => log.LogGroupName == secondLogGroup),
+                It.IsAny<System.Threading.CancellationToken>()),
                 Times.Once);
 
             _mockContext.Verify(x => x.SaveChangesAsync(default), Times.Exactly(2));

--- a/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
@@ -231,7 +231,6 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             // Arrange
             var logGroupName = "test-log-group";
             var today = DateTime.UtcNow;
-            var sequence = new MockSequence();
 
             var errorResults = new List<List<ResultField>>
             {
@@ -271,7 +270,6 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
             // Arrange
             var logGroupName = "test-log-group";
             var today = DateTime.UtcNow;
-            var sequence = new MockSequence();
 
             var errorResults = new List<List<ResultField>>
             {

--- a/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
@@ -1,6 +1,7 @@
 using Amazon.CloudWatchLogs.Model;
 using HousingFinanceInterimApi.V1.Gateways;
 using HousingFinanceInterimApi.V1.Infrastructure;
+using HousingFinanceInterimApi.V1.Domain;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using System;
@@ -195,6 +196,72 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
                 log.LogGroupName == logGroupName &&
                 log.IsSuccess == null), default), Times.Once);
             _mockContext.Verify(x => x.SaveChangesAsync(default), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateDatabaseWithResults_Case4_LogsExistButMandatorySuccessMessageMissing()
+        {
+            // Arrange
+            var logGroupName = "test-log-group";
+            var queryResults = new List<List<ResultField>>
+            {
+                new List<ResultField>
+                {
+                    // This matches Case 4 in your Use Case
+                    new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff") },
+                    new ResultField { Field = "@message", Value = $"error: Mandatory success message '{Constants.ProcessCompletedSuccessfullyMessage}' not found." }
+                }
+            };
+
+            // Act
+            await _gateway.UpdateDatabaseWithResults(logGroupName, queryResults);
+
+            // Assert
+            _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
+                It.Is<NightlyProcessLog>(log =>
+                    log.LogGroupName == logGroupName &&
+                    log.IsSuccess == false), 
+                It.IsAny<System.Threading.CancellationToken>()),
+                Times.Once);
+        }
+        
+        [Fact]
+        public async Task ProcessingMultipleLogGroupsSavesOneResultPerGroup()
+        {
+            // Arrange
+            var firstLogGroup = "log-group-1";
+            var secondLogGroup = "log-group-2";
+
+            var results1 = new List<List<ResultField>> {
+                new List<ResultField> { 
+                    new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("o") },
+                    new ResultField { Field = "@message", Value = "Error in group 1" } 
+                }
+            };
+
+            var results2 = new List<List<ResultField>> {
+                new List<ResultField> { 
+                    new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("o") },
+                    new ResultField { Field = "@message", Value = "Error in group 2" } 
+                }
+            };
+
+            // Act
+            await _gateway.UpdateDatabaseWithResults(firstLogGroup, results1);
+            await _gateway.UpdateDatabaseWithResults(secondLogGroup, results2);
+
+            // Assert
+            _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
+                It.Is<NightlyProcessLog>(log => log.LogGroupName == firstLogGroup), 
+                It.IsAny<System.Threading.CancellationToken>()), 
+                Times.Once);
+
+            _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
+                It.Is<NightlyProcessLog>(log => log.LogGroupName == secondLogGroup), 
+                It.IsAny<System.Threading.CancellationToken>()), 
+                Times.Once);
+
+            _mockContext.Verify(x => x.SaveChangesAsync(default), Times.Exactly(2));
         }
     }
 }

--- a/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
@@ -226,42 +226,136 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task ProcessingMultipleLogGroups_SavesOneResultPerGroup()
+        public async Task UpdateDatabaseWithResults_IgnoresOlderErrors_IfMostRecentIsSuccess()
+        {
+            // Arrange
+            var logGroupName = "test-log-group";
+            var today = DateTime.UtcNow;
+            var sequence = new MockSequence();
+
+            var errorResults = new List<List<ResultField>>
+            { 
+                new List<ResultField>
+                {
+                    new ResultField { Field = "@timestamp", Value = today.AddMinutes(-10).ToString("o") },
+                    new ResultField { Field = "@message", Value = "Initial Critical Error" }
+                }
+            };
+
+            var successResults = new List<List<ResultField>>();
+
+            NightlyProcessLog lastLogSaved = null; 
+
+            _mockDbSet.Setup(x => x.AddAsync(It.IsAny<NightlyProcessLog>(), It.IsAny<System.Threading.CancellationToken>()))
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((log, token) => 
+                {
+                    lastLogSaved = log;
+                })
+                .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
+
+            // 2. Act
+            await _gateway.UpdateDatabaseWithResults(logGroupName, errorResults).ConfigureAwait(false);
+            await _gateway.UpdateDatabaseWithResults(logGroupName, successResults).ConfigureAwait(false);
+
+            // 3. Assert
+            Assert.NotNull(lastLogSaved);
+        
+            Assert.True(lastLogSaved.IsSuccess);
+            
+            Assert.Equal(logGroupName, lastLogSaved.LogGroupName);
+        }
+
+        [Fact]
+        public async Task UpdateDatabaseWithResults_SavesError_IfMostRecentIsError()
+        {
+            // Arrange
+            var logGroupName = "test-log-group";
+            var today = DateTime.UtcNow;
+            var sequence = new MockSequence();
+
+            var errorResults = new List<List<ResultField>>
+            { 
+                new List<ResultField>
+                {
+                    new ResultField { Field = "@timestamp", Value = today.ToString("o") },
+                    new ResultField { Field = "@message", Value = "Initial Critical Error" }
+                }
+            };
+
+            var successResults = new List<List<ResultField>>();
+
+            NightlyProcessLog lastLogSaved = null; 
+
+            _mockDbSet.Setup(x => x.AddAsync(It.IsAny<NightlyProcessLog>(), It.IsAny<System.Threading.CancellationToken>()))
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((log, token) => 
+                {
+                    lastLogSaved = log;
+                })
+                .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
+
+            // Act
+            await _gateway.UpdateDatabaseWithResults(logGroupName, successResults).ConfigureAwait(false);
+            await _gateway.UpdateDatabaseWithResults(logGroupName, errorResults).ConfigureAwait(false);
+
+            // Assert
+            Assert.NotNull(lastLogSaved);
+        
+            Assert.False(lastLogSaved.IsSuccess);
+            
+            Assert.Equal(logGroupName, lastLogSaved.LogGroupName);
+        }
+
+        [Fact]
+        public async Task ProcessingMultipleLogGroups_SavesMostRecentResultPerGroup()
         {
             // Arrange
             var firstLogGroup = "log-group-1";
             var secondLogGroup = "log-group-2";
+            var today = DateTime.UtcNow;
+            var sequence = new MockSequence();
+            var finalStates = new Dictionary<string, bool>();
 
-            var results1 = new List<List<ResultField>> {
-                new List<ResultField> {
-                    new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("o") },
-                    new ResultField { Field = "@message", Value = "Error in group 1" }
+            var errorResults = new List<List<ResultField>>
+            { 
+                new List<ResultField>
+                {
+                    new ResultField { Field = "@timestamp", Value = today.ToString("o") },
+                    new ResultField { Field = "@message", Value = "Initial Critical Error" }
                 }
             };
 
-            var results2 = new List<List<ResultField>> {
-                new List<ResultField> {
-                    new ResultField { Field = "@timestamp", Value = DateTime.UtcNow.ToString("o") },
-                    new ResultField { Field = "@message", Value = "Error in group 2" }
-                }
-            };
+            var successResults = new List<List<ResultField>>();
+
+            // SCRIPT STEP 1 & 2: Group 1 goes from Error to Success
+            _mockDbSet.InSequence(sequence).Setup(x => x.AddAsync(It.Is<NightlyProcessLog>(l => l.LogGroupName == firstLogGroup && l.IsSuccess.GetValueOrDefault() == false), It.IsAny<System.Threading.CancellationToken>()))
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((l, t) => finalStates[firstLogGroup] = l.IsSuccess.GetValueOrDefault())
+                .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
+
+            _mockDbSet.InSequence(sequence).Setup(x => x.AddAsync(It.Is<NightlyProcessLog>(l => l.LogGroupName == firstLogGroup && l.IsSuccess.GetValueOrDefault() == true), It.IsAny<System.Threading.CancellationToken>()))
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((l, t) => finalStates[firstLogGroup] = l.IsSuccess.GetValueOrDefault())
+                .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
+
+            // SCRIPT STEP 3 & 4: Group 2 goes from Error to Success
+            _mockDbSet.InSequence(sequence).Setup(x => x.AddAsync(It.Is<NightlyProcessLog>(l => l.LogGroupName == secondLogGroup && l.IsSuccess.GetValueOrDefault() == true), It.IsAny<System.Threading.CancellationToken>()))
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((l, t) => finalStates[secondLogGroup] = l.IsSuccess.GetValueOrDefault())
+                .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
+
+            _mockDbSet.InSequence(sequence).Setup(x => x.AddAsync(It.Is<NightlyProcessLog>(l => l.LogGroupName == secondLogGroup && l.IsSuccess.GetValueOrDefault() == false), It.IsAny<System.Threading.CancellationToken>()))
+                .Callback<NightlyProcessLog, System.Threading.CancellationToken>((l, t) => finalStates[secondLogGroup] = l.IsSuccess.GetValueOrDefault())
+                .ReturnsAsync((NightlyProcessLog l, System.Threading.CancellationToken c) => null);
 
             // Act
-            await _gateway.UpdateDatabaseWithResults(firstLogGroup, results1).ConfigureAwait(false);
-            await _gateway.UpdateDatabaseWithResults(secondLogGroup, results2).ConfigureAwait(false);
+            await _gateway.UpdateDatabaseWithResults(firstLogGroup, errorResults).ConfigureAwait(false);
+            await _gateway.UpdateDatabaseWithResults(firstLogGroup, successResults).ConfigureAwait(false);
+
+            await _gateway.UpdateDatabaseWithResults(secondLogGroup, successResults).ConfigureAwait(false);
+            await _gateway.UpdateDatabaseWithResults(secondLogGroup, errorResults).ConfigureAwait(false);
 
             // Assert
-            _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
-                It.Is<NightlyProcessLog>(log => log.LogGroupName == firstLogGroup),
-                It.IsAny<System.Threading.CancellationToken>()),
-                Times.Once);
+            _mockDbSet.Verify(x => x.AddAsync(It.IsAny<NightlyProcessLog>(), It.IsAny<System.Threading.CancellationToken>()), Times.Exactly(4));
 
-            _mockContext.Verify(x => x.NightlyProcessLogs.AddAsync(
-                It.Is<NightlyProcessLog>(log => log.LogGroupName == secondLogGroup),
-                It.IsAny<System.Threading.CancellationToken>()),
-                Times.Once);
-
-            _mockContext.Verify(x => x.SaveChangesAsync(default), Times.Exactly(2));
+            Assert.True(finalStates[firstLogGroup]);
+            Assert.False(finalStates[secondLogGroup]);
         }
     }
 }

--- a/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
+++ b/HousingFinanceInterimApi.Tests/V1/Gateways/NightlyProcessLogGatewayTests.cs
@@ -30,7 +30,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsShouldSaveToDatabaseAsFailWhenValidInputHasError()
+        public async Task UpdateDatabaseWithResults_ShouldSaveToDatabaseAsFail_WhenValidInputHasError()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -52,7 +52,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsShouldThrowArgumentNullExceptionWhenLogGroupNameIsNull()
+        public async Task UpdateDatabaseWithResults_ShouldThrowArgumentNullException_WhenLogGroupNameIsNull()
         {
             // Arrange
             string logGroupName = null;
@@ -64,7 +64,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsShouldLogAndThrowWhenDbUpdateException()
+        public async Task UpdateDatabaseWithResults_ShouldLogAndThrow_WhenDbUpdateException()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -87,7 +87,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsShouldAddFailureWhenErrorExists()
+        public async Task UpdateDatabaseWithResults_ShouldAddFailure_WhenErrorExists()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -114,7 +114,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsShouldStopProcessingOnFirstError()
+        public async Task UpdateDatabaseWithResults_ShouldStopProcessingOnFirstError()
         {
             // Arrange
             var logGroupName = "/aws/lambda/log-group-function1";
@@ -141,7 +141,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsCase1ResultsExistForKeyword()
+        public async Task UpdateDatabaseWithResults_Case1_ResultsExistForKeyword()
         {
             // Arrange
             var logGroupName = "test-log-group";
@@ -165,7 +165,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsCase2LogsExistButNoMatchForKeyword()
+        public async Task UpdateDatabaseWithResults_Case2_LogsExistButNoMatchForKeyword()
         {
             // Arrange
             var logGroupName = "test-log-group";
@@ -182,7 +182,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsCase3NoLogsExistForLogGroup()
+        public async Task UpdateDatabaseWithResults_Case3_NoLogsExistForLogGroup()
         {
             // Arrange
             var logGroupName = "test-log-group";
@@ -199,7 +199,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task UpdateDatabaseWithResultsCase4LogsExistButMandatorySuccessMessageMissing()
+        public async Task UpdateDatabaseWithResults_Case4_LogsExistButMandatorySuccessMessageMissing()
         {
             // Arrange
             var logGroupName = "test-log-group";
@@ -226,7 +226,7 @@ namespace HousingFinanceInterimApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task ProcessingMultipleLogGroupsSavesOneResultPerGroup()
+        public async Task ProcessingMultipleLogGroups_SavesOneResultPerGroup()
         {
             // Arrange
             var firstLogGroup = "log-group-1";

--- a/HousingFinanceInterimApi/V1/Gateways/NightlyProcessLogGateway.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/NightlyProcessLogGateway.cs
@@ -145,6 +145,8 @@ namespace HousingFinanceInterimApi.V1.Gateways
                 return await _context.NightlyProcessLogs
                     .Where(log => log.DateCreated.Date == createdDate.Date)
                     .OrderByDescending(log => log.DateCreated)
+                    .GroupBy(log => log.LogGroupName)
+                    .Select(group => group.First())
                     .ToListAsync()
                     .ConfigureAwait(false);
             }


### PR DESCRIPTION
## Link to JIRA ticket

[Add a link to the JIRA ticket that the changes in this PR describe.](https://hackney.atlassian.net/jira/software/projects/HT/boards/428?jql=assignee%20%3D%20712020%3Aec561b5f-6107-4deb-a8e8-198d5103ad0e&selectedIssue=HT-847)

## Describe this PR

### *What is the problem we're trying to solve*

This banner having duplicate errors **(not currently shown)**:

<img width="1468" height="284" alt="image" src="https://github.com/user-attachments/assets/0badeed6-f0c8-4021-905a-5878dd59e610" />

### *What changes have we introduced*

Only return the last log for each log group.