### PR TITLE
Add scheduler perms to lambda

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -572,6 +572,7 @@ resources:
               Principal:
                 Service:
                   - lambda.amazonaws.com
+                  - scheduler.amazonaws.com
               Action: sts:AssumeRole
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole


### PR DESCRIPTION
Need this to give serverless permission to hook up new eventbridge to lambda.

See #217