### PR TITLE
Truncate direct debit aux for performance

### DIFF
--- a/HousingFinanceInterimApi/V1/Infrastructure/DatabaseContext.cs
+++ b/HousingFinanceInterimApi/V1/Infrastructure/DatabaseContext.cs
@@ -424,7 +424,7 @@ namespace HousingFinanceInterimApi.V1.Infrastructure
 
         public async Task TruncateDirectDebitAuxiliary()
         {
-            var sql = "DELETE FROM DirectDebitAux";
+            var sql = "TRUNCATE TABLE DirectDebitAux";
             await PerformTransaction(sql).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
We had an overnight failure last night due to the `DELETE FROM DirectDebitAux` taking too long.

We can speed it up by switching to `TRUNCATE TABLE`

This is safe because the ID column is not used by the LoadDirectDebit stored procedure