### PR TITLE
Loop through google file settings and log id and file type for each one

### DIFF
--- a/HousingFinanceInterimApi/V1/Gateways/GoogleFileSettingGateway.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/GoogleFileSettingGateway.cs
@@ -30,6 +30,10 @@ namespace HousingFinanceInterimApi.V1.Gateways
             {
                 var googleFileSettings = _context.GoogleFileSettings
                     .Where(item => item.Label.Equals(label)).ToList();
+                foreach (var setting in googleFileSettings)
+                {
+                    LoggingHandler.LogInfo($"Setting Id: {setting.Id}, File Type: {setting.FileType}");
+                }
                 return Task.FromResult(googleFileSettings.ToDomain());
             }
             catch (Exception e)
@@ -41,3 +45,4 @@ namespace HousingFinanceInterimApi.V1.Gateways
         }
     }
 }
+


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We can't view the setting id and file type for each Google File Setting which makes it difficult to debug in AWS.

### *What changes have we introduced*

Loop and log all the setting ids and file types before returning. 