### PR TITLE
Switch to the Cognito authorizer on `staging` environment.

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1091,7 +1091,7 @@ custom:
     includeLayers: true
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   associateWaf:
     name: Platform_APIs_Web_ACL


### PR DESCRIPTION
# What:
 - Switch the HFS API to the Cognito authorizer on `staging` environment.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `staging`.