### PR TITLE
Fix deploy lambda error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,25 +125,25 @@ workflows:
   check-and-deploy-development:
     jobs:
       - check-code-formatting        
-      # - build-and-test:
-      #     context:
-      #       - api-nuget-token-context
+      - build-and-test:
+          context:
+            - api-nuget-token-context
       - assume-role-development:
           context: api-assume-role-housing-development-context
-          # requires:
-          #   - build-and-test
-          # filters:
-          #   branches:
-          #     only: development
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: development
       - deploy-to-development:
           context:
             - api-nuget-token-context
             - "Serverless Framework"
           requires:
             - assume-role-development  
-          # filters:
-          #   branches:
-          #     only: development     
+          filters:
+            branches:
+              only: development     
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,9 +125,9 @@ workflows:
   check-and-deploy-development:
     jobs:
       - check-code-formatting        
-      - build-and-test:
-          context:
-            - api-nuget-token-context
+      # - build-and-test:
+      #     context:
+      #       - api-nuget-token-context
       - assume-role-development:
           context: api-assume-role-housing-development-context
           # requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,20 +130,20 @@ workflows:
             - api-nuget-token-context
       - assume-role-development:
           context: api-assume-role-housing-development-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: development
+          # requires:
+          #   - build-and-test
+          # filters:
+          #   branches:
+          #     only: development
       - deploy-to-development:
           context:
             - api-nuget-token-context
             - "Serverless Framework"
           requires:
             - assume-role-development  
-          filters:
-            branches:
-              only: development     
+          # filters:
+          #   branches:
+          #     only: development     
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1073,25 +1073,41 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-query-nightly-logs
+    SpreadsheetParsingInsightRule:
+      Type: AWS::CloudWatch::InsightRule
+      Properties:
+        RuleName: "${self:provider.stage}-SpreadsheetParsingRule"
+        RuleState: ENABLED
+        RuleBody: |
+          {
+            "Schema": { "Name": "CloudWatchLogRule", "Version": 1 },
+            "LogGroupNames": [
+              "/aws/lambda/${self:service}-${self:provider.stage}-load-tenagree",
+              "/aws/lambda/${self:service}-${self:provider.stage}-action-diary",
+              "/aws/lambda/${self:service}-${self:provider.stage}-susp-cash",
+              "/aws/lambda/${self:service}-${self:provider.stage}-susp-hb",
+              "/aws/lambda/${self:service}-${self:provider.stage}-adjustments-trans",
+              "/aws/lambda/${self:service}-${self:provider.stage}-charges",
+              "/aws/lambda/${self:service}-${self:provider.stage}-direct-debit"
+            ],
+            "LogFormat": "CLF",
+            "Contribution": {
+              "Keys": ["@log"],
+              "Filters": [
+                { "Match": "ALARM: Spreadsheet row parsing failed", "In": ["@message"] }
+              ]
+            }
+          }
     SpreadsheetParsingAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: "${self:provider.stage}-spreadsheet-parsing-alarm"
-        AlarmDescription: "Spreadsheet row parsing failed in one of the import processes. Check the alert metadata to see exactly which Log Group failed."
+        AlarmDescription: "Spreadsheet row parsing failed. Check the alert metadata (Top Contributors) to see exactly which Log Group failed."
         Metrics:
           - Id: "ad1"
-            Label: "SpreadsheetParsingErrors"
+            Expression: "INSIGHT_RULE_METRIC(\"${self:provider.stage}-SpreadsheetParsingRule\", \"SampleCount\")"
+            Label: "ParsingErrorsByFunction"
             ReturnData: true
-            Expression: |
-              SELECT COUNT(*) FROM SOURCE(
-                '/aws/lambda/${self:service}-${self:provider.stage}-load-tenagree',
-                '/aws/lambda/${self:service}-${self:provider.stage}-action-diary',
-                '/aws/lambda/${self:service}-${self:provider.stage}-susp-cash',
-                '/aws/lambda/${self:service}-${self:provider.stage}-susp-hb',
-                '/aws/lambda/${self:service}-${self:provider.stage}-adjustments-trans',
-                '/aws/lambda/${self:service}-${self:provider.stage}-charges',
-                '/aws/lambda/${self:service}-${self:provider.stage}-direct-debit'
-              ) WHERE @message LIKE 'ALARM: Spreadsheet row parsing failed'
             Period: 300
         Threshold: 0
         ComparisonOperator: GreaterThanThreshold

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1078,7 +1078,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-load-tenagree
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"
@@ -1104,7 +1104,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-action-diary
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"
@@ -1130,7 +1130,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-susp-cash
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"
@@ -1156,7 +1156,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-susp-hb
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"
@@ -1182,7 +1182,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-adjustments-trans
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"
@@ -1208,7 +1208,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-charges
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"
@@ -1234,7 +1234,7 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-direct-debit
-        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: "HousingFinance/SpreadsheetErrors"

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1095,7 +1095,8 @@ resources:
               "Keys": ["@log"],
               "Filters": [
                 { "Match": "ALARM: Spreadsheet row parsing failed", "In": ["@message"] }
-              ]
+              ],
+              "AggregateOn": "Count"
             }
           }
     SpreadsheetParsingAlarm:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1073,64 +1073,188 @@ resources:
         Dimensions:
           - Name: FunctionName
             Value: ${self:service}-${self:provider.stage}-query-nightly-logs
-    SpreadsheetParsingInsightRule:
-      Type: AWS::CloudWatch::InsightRule
+
+    LoadTenancyAgreementSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
       Properties:
-        RuleName: "${self:provider.stage}-SpreadsheetParsingRule"
-        RuleState: ENABLED
-        RuleBody: |
-          {
-            "Schema": { "Name": "CloudWatchLogRule", "Version": 1 },
-            "LogGroupNames": [
-              "/aws/lambda/${self:service}-${self:provider.stage}-load-tenagree",
-              "/aws/lambda/${self:service}-${self:provider.stage}-action-diary",
-              "/aws/lambda/${self:service}-${self:provider.stage}-susp-cash",
-              "/aws/lambda/${self:service}-${self:provider.stage}-susp-hb",
-              "/aws/lambda/${self:service}-${self:provider.stage}-adjustments-trans",
-              "/aws/lambda/${self:service}-${self:provider.stage}-charges",
-              "/aws/lambda/${self:service}-${self:provider.stage}-direct-debit"
-            ],
-            "LogFormat": "CLF",
-            "Contribution": {
-              "Keys": ["@log"],
-              "Filters": [
-                { "Match": "ALARM: Spreadsheet row parsing failed", "In": ["@message"] }
-              ]
-            },
-            "AggregateOn": "Count"
-          }
-    SpreadsheetParsingAlarm:
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-load-tenagree
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "LoadTenancyAgreementSpreadsheetErrors"
+
+    LoadTenancyAgreementSpreadsheetAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
-        AlarmName: "${self:provider.stage}-spreadsheet-parsing-alarm"
-        AlarmDescription: "Spreadsheet row parsing failed. Check the alert metadata (Top Contributors) to see exactly which Log Group failed."
-        Metrics:
-          - Id: "ad1"
-            Expression: "INSIGHT_RULE_METRIC(\"${self:provider.stage}-SpreadsheetParsingRule\", \"SampleCount\")"
-            Label: "ParsingErrorsByFunction"
-            ReturnData: true
-            Period: 300
+        AlarmName: "${self:provider.stage}-load-tenagree-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the load-tenagree function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "LoadTenancyAgreementSpreadsheetErrors"
+        Statistic: Sum
         Threshold: 0
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
+        Period: 60
         TreatMissingData: notBreaching
         AlarmActions:
-          - 'Fn::Join':
-              - ':'
-              - - 'arn:aws:sns'
-                - Ref: 'AWS::Region'
-                - Ref: 'AWS::AccountId'
-                - 'housing-finance-alarms'
-    LambdaSecurityGroup:
-      Type: AWS::EC2::SecurityGroup
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
+    ActionDiarySpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
       Properties:
-        GroupDescription: "Lambda SG for ${self:service} (${self:provider.stage}) - replaces use of the VPC default SG"
-        VpcId: ${self:custom.vpc.${opt:stage}.vpcId}
-        Tags:
-          - Key: Team
-            Value: HousingFinance
-          - Key: Name
-            Value: ${self:service}-${self:provider.stage}-lambda-sg
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-action-diary
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "ActionDiarySpreadsheetErrors"
+
+    ActionDiarySpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-action-diary-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the action-diary function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "ActionDiarySpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
+    SuspenseCashSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-susp-cash
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "SuspenseCashSpreadsheetErrors"
+
+    SuspenseCashSpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-susp-cash-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the susp-cash function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "SuspenseCashSpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
+    SuspenseHBSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-susp-hb
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "SuspenseHBSpreadsheetErrors"
+
+    SuspenseHBSpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-susp-hb-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the susp-hb function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "SuspenseHBSpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
+    AdjustmentsTransSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-adjustments-trans
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "AdjustmentsTransSpreadsheetErrors"
+
+    AdjustmentsTransSpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-adjustments-trans-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the adjustments-trans function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "AdjustmentsTransSpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
+    ChargesSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-charges
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "ChargesSpreadsheetErrors"
+
+    ChargesSpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-charges-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the charges function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "ChargesSpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
+    DirectDebitSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${self:provider.stage}-direct-debit
+        FilterPattern: "ALARM: Spreadsheet row parsing failed"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "DirectDebitSpreadsheetErrors"
+
+    DirectDebitSpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-direct-debit-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the direct-debit function."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "DirectDebitSpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
 
 custom:
   prune:

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1095,9 +1095,9 @@ resources:
               "Keys": ["@log"],
               "Filters": [
                 { "Match": "ALARM: Spreadsheet row parsing failed", "In": ["@message"] }
-              ],
-              "AggregateOn": "Count"
-            }
+              ]
+            },
+            "AggregateOn": "Count"
           }
     SpreadsheetParsingAlarm:
       Type: AWS::CloudWatch::Alarm

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1092,10 +1092,10 @@ resources:
                 '/aws/lambda/${self:service}-${self:provider.stage}-charges',
                 '/aws/lambda/${self:service}-${self:provider.stage}-direct-debit'
               ) WHERE @message LIKE 'ALARM: Spreadsheet row parsing failed'
+            Period: 300
         Threshold: 0
         ComparisonOperator: GreaterThanThreshold
         EvaluationPeriods: 1
-        Period: 300
         TreatMissingData: notBreaching
         AlarmActions:
           - 'Fn::Join':

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1256,6 +1256,17 @@ resources:
         AlarmActions:
           - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
 
+    LambdaSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+        GroupDescription: "Lambda SG for ${self:service} (${self:provider.stage}) - replaces use of the VPC default SG"
+        VpcId: ${self:custom.vpc.${opt:stage}.vpcId}
+        Tags:
+          - Key: Team
+            Value: HousingFinance
+          - Key: Name
+            Value: ${self:service}-${self:provider.stage}-lambda-sg
+
 custom:
   prune:
     automatic: true


### PR DESCRIPTION
After the previous PR #252 I ran into the following error:

<img width="1716" height="727" alt="image" src="https://github.com/user-attachments/assets/cd5d1497-e362-40dd-a723-ff2b2598f72b" />

 ## What changes have we introduced
Replaced the single SpreadsheetParsingInsightRule and SpreadsheetParsingAlarm in serverless.yml with individual CloudWatch Metric Filters and Alarms for each of the 7 spreadsheet-processing Lambda functions. This ensures that when a spreadsheet parsing error occurs, the resulting SNS alarm email explicitly identifies the exact Lambda function that failed, which was not possible with a single consolidated alarm.