### PR TITLE
Add enabled flag to overnight schedules

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -75,6 +75,7 @@ functions:
             rate: cron(0 0 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   importCashFile:
     name: ${self:service}-${self:provider.stage}-cash-file
     description: "The scheduler to import cash files from Google drives."
@@ -125,6 +126,7 @@ functions:
             rate: cron(45 6 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   refreshManageArrearsTables:
     name: ${self:service}-${self:provider.stage}-refresh-ma-cur-bal
     description: "The scheduler to refresh manage arrears balance based on current balance table."
@@ -188,6 +190,7 @@ functions:
             rate: cron(0 3 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   generateRentPosition:
     name: ${self:service}-${self:provider.stage}-rent-position
     description: "The scheduler to generate rent position csv file. Run at 05:00 AM"
@@ -199,6 +202,7 @@ functions:
             rate: cron(15 7 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   importAdjustmentsTransactions:
     name: ${self:service}-${self:provider.stage}-adjustments-trans
     description: "The scheduler to import adjustments transactions from spreadsheet. Runs at 2:45 AM."
@@ -210,6 +214,7 @@ functions:
             rate: cron(45 2 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   suspenseCash:
     name: ${self:service}-${self:provider.stage}-susp-cash
     description: "The scheduler to load and reverse suspense cash files. Run at 03:05 AM"
@@ -221,6 +226,7 @@ functions:
             rate: cron(5 3 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   suspenseHousingBenefit:
     name: ${self:service}-${self:provider.stage}-susp-hb
     description: "The scheduler to load and reverse suspense hb files. Run at 03:10 AM"
@@ -232,6 +238,7 @@ functions:
             rate: cron(10 3 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
   generateReport:
     name: ${self:service}-${self:provider.stage}-gen-report
     description: "The scheduler to generate google drive reports."
@@ -249,6 +256,7 @@ functions:
             rate: cron(30 7 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
 stepFunctions:
   stateMachines:
     hfstepfunccashfile:
@@ -258,6 +266,7 @@ stepFunctions:
             rate: cron(0 2 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
       definition:
         Comment: "Cash files process step function deployed via serverless. Run at 02:00 AM"
         StartAt: ImportCashFile
@@ -300,6 +309,7 @@ stepFunctions:
             rate: cron(0 6 ? * MON *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
       definition:
         Comment: "Housing files process step function deployed via serverless. Run at 06:00 AM only Monday"        
         StartAt: CheckHousingFiles
@@ -357,6 +367,7 @@ stepFunctions:
             rate: cron(30 2 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
       definition:
         Comment: "Direct debit process step function deployed via serverless. Run at 02:30 AM"
         StartAt: ImportDirectDebit
@@ -401,84 +412,6 @@ stepFunctions:
       dependsOn: lambdaExecutionRole
       tags:
         Team: HousingFinance
-    # hfstepfunccharges:
-    #   name: HFChargesStateMachine
-    #   events:
-    #     - schedule: cron(30 0 * * ? *)
-    #   definition:
-    #     Comment: "Charges process step function deployed via serverless. Run at 12:30 AM"
-    #     StartAt: CheckChargesBatchYears
-    #     States:
-    #       CheckChargesBatchYears:
-    #         Type: Task
-    #         Resource:
-    #           Fn::GetAtt: [ checkChargesBatchYears, Arn ]
-    #         Retry:
-    #           - ErrorEquals:
-    #               - States.All
-    #             IntervalSeconds: 30
-    #             MaxAttempts: 3
-    #             BackoffRate: 2
-    #         Next: Choice_ExistPendingYear
-    #       Choice_ExistPendingYear:
-    #         Type: Choice
-    #         Choices:
-    #           - Variable: $.Continue
-    #             BooleanEquals: true
-    #             Next: Wait_0
-    #           - Variable: $.Continue
-    #             BooleanEquals: false
-    #             Next: EndStep
-    #       Wait_0:
-    #           Type: Wait
-    #           TimestampPath: $.NextStepTime
-    #           Next: ImportCharges
-    #       ImportCharges:
-    #         Type: Task
-    #         Resource:
-    #           Fn::GetAtt: [ importCharges, Arn ]
-    #         Retry:
-    #           - ErrorEquals:
-    #               - States.All
-    #             IntervalSeconds: 30
-    #             MaxAttempts: 3
-    #             BackoffRate: 2
-    #         Next: Wait_1          
-    #       Wait_1:
-    #           Type: Wait
-    #           TimestampPath: $.NextStepTime
-    #           Next: ImportChargesHistory
-    #       ImportChargesHistory:
-    #         Type: Task
-    #         Resource:
-    #           Fn::GetAtt: [ importChargesHistory, Arn ]
-    #         Retry:
-    #           - ErrorEquals:
-    #               - States.All
-    #             IntervalSeconds: 30
-    #             MaxAttempts: 3
-    #             BackoffRate: 2
-    #         Next: Wait_2
-    #       Wait_2:
-    #           Type: Wait
-    #           TimestampPath: $.NextStepTime
-    #           Next: ImportChargesTransactions          
-    #       ImportChargesTransactions:
-    #         Type: Task
-    #         Resource:
-    #           Fn::GetAtt: [ importChargesTransactions, Arn ]
-    #         Retry:
-    #           - ErrorEquals:
-    #               - States.All
-    #             IntervalSeconds: 30
-    #             MaxAttempts: 3
-    #             BackoffRate: 2
-    #         Next: CheckChargesBatchYears
-    #       EndStep:
-    #         Type: Succeed
-    #   dependsOn: lambdaExecutionRole
-    #   tags:
-    #     Team: HousingFinance
     hfstepfunccurentbalance:
       name: HFCurrentBalanceStateMachine
       events:
@@ -486,6 +419,7 @@ stepFunctions:
             rate: cron(10 6 * * ? *)
             timezone: Europe/London
             method: scheduler
+            enabled: ${self:custom.schedulesEnabled}
       definition:
         Comment: "Current balance process step function deployed via serverless. Run at 06:10 AM"
         StartAt: RefreshCurrentBalance
@@ -1085,6 +1019,7 @@ resources:
             Value: ${self:service}-${self:provider.stage}-lambda-sg
 
 custom:
+  schedulesEnabled: true
   prune:
     automatic: true
     number: 10


### PR DESCRIPTION
Related to https://github.com/LBHackney-IT/mtfh-finance-infrastructure/pull/67

Need this flag to reduce risk from releasing the finance process orchestrator.

In case of failure we can revert by simply fliping these enabled flags.

For now left them true - so the current automated process will continue as before.