### PR TITLE
Switch the `production` HFS API lambda's authorizer to the new one that supports Cognito authentication flow.

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1210,7 +1210,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-gateway-lambda-authorizer
   associateWaf:
     name: Platform_APIs_Web_ACL
     version: V2


### PR DESCRIPTION
# What:
 - Switches the legacy authorizer lambda for the new cognito authentication supporting lambda.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `production`.

# Notes:
 - Related to: #209 .
 - Related to: #249 and #250 .