### PR TITLE
Disable schedule to release orchestrator

### DIFF
--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1202,7 +1202,7 @@ resources:
             Value: ${self:service}-${self:provider.stage}-lambda-sg
 
 custom:
-  schedulesEnabled: true
+  schedulesEnabled: false
   prune:
     automatic: true
     number: 10


### PR DESCRIPTION
[HT-809](https://hackney.atlassian.net/browse/HT-809)

Relates to: https://github.com/LBHackney-IT/hfs-overnight-process-orchestrator/pull/10

Switches the schedules enabled flag to false to release the finance process orchestrator

[HT-809]: https://hackney.atlassian.net/browse/HT-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ