### PR TITLE
HT-925: Add alarm infra for charges container

### DIFF
--- a/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
+++ b/HousingFinanceInterimApi/V1/Gateways/GoogleClientService.cs
@@ -354,11 +354,11 @@ namespace HousingFinanceInterimApi.V1.Gateways
                 var entities = new List<_TEntity>();
                 bool hasErrors = false;
 
-                foreach (var rowObject in rowObjects)
+                for (int i = 0; i < rowObjects.Count; i++)
                 {
                     try
                     {
-                        string convertedJson = JsonConvert.SerializeObject(rowObject);
+                        string convertedJson = JsonConvert.SerializeObject(rowObjects[i]);
                         var entity = JsonConvert.DeserializeObject<_TEntity>(convertedJson);
                         if (entity != null)
                         {
@@ -368,7 +368,8 @@ namespace HousingFinanceInterimApi.V1.Gateways
                     catch (Exception exc)
                     {
                         hasErrors = true;
-                        LoggingHandler.LogWarning($"Skip row: Failure parsing row. Message: {exc.Message}");
+                        int spreadsheetRowNumber = i + 2; // exclude header
+                        LoggingHandler.LogWarning($"Skip row: Failure parsing row {spreadsheetRowNumber}. Message: {exc.Message}");
                     }
                 }
 

--- a/HousingFinanceInterimApi/serverless.yml
+++ b/HousingFinanceInterimApi/serverless.yml
@@ -1164,6 +1164,32 @@ resources:
         AlarmActions:
           - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
 
+    ChargesIngestSpreadsheetFilter:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName: hfs-nightly-jobs-charges-ingest-ecs-task-logs
+        FilterPattern: '"ALARM: Spreadsheet row parsing failed"'
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: "HousingFinance/SpreadsheetErrors"
+            MetricName: "ChargesIngestSpreadsheetErrors"
+
+    ChargesIngestSpreadsheetAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: "${self:provider.stage}-charges-ingest-spreadsheet-alarm"
+        AlarmDescription: "Spreadsheet row parsing failed in the HfsChargesContainer Fargate task (hfs-nightly-jobs-charges-ingest)."
+        Namespace: "HousingFinance/SpreadsheetErrors"
+        MetricName: "ChargesIngestSpreadsheetErrors"
+        Statistic: Sum
+        Threshold: 0
+        ComparisonOperator: GreaterThanThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - 'Fn::Join': [ ':', [ 'arn:aws:sns', Ref: 'AWS::Region', Ref: 'AWS::AccountId', 'housing-finance-alarms' ] ]
+
     DirectDebitSpreadsheetFilter:
       Type: AWS::Logs::MetricFilter
       Properties:


### PR DESCRIPTION
HfsChargesContainer (Fargate) will log ALARM: Spreadsheet row parsing failed when rows are skipped ([HfsChargesContainer#36](https://github.com/LBHackney-IT/HfsChargesContainer/pull/36) / HT-925, adding the resilient parsing from [interim-api#252](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/252)). Nothing watches the ECS log group yet, so the SNS is never fired. Only the Lambda charges path already has a MetricFilter + Alarm.